### PR TITLE
feat(cypress): add fixtures for testing

### DIFF
--- a/cypress/fixtures/artist-songs/ac-dc.json
+++ b/cypress/fixtures/artist-songs/ac-dc.json
@@ -1,0 +1,42 @@
+[
+    {
+        "title": "Highway to Hell",
+        "path": "highway-to-hell"
+    },
+    {
+        "title": "Back in Black",
+        "path": "back-in-black"
+    },
+    {
+        "title": "Thunderstruck",
+        "path": "thunderstruck"
+    },
+    {
+        "title": "You Shook Me All Night Long",
+        "path": "you-shook-me-all-night-long"
+    },
+    {
+        "title": "Hells Bells",
+        "path": "hells-bells"
+    },
+    {
+        "title": "T.N.T.",
+        "path": "tnt"
+    },
+    {
+        "title": "Dirty Deeds Done Dirt Cheap",
+        "path": "dirty-deeds-done-dirt-cheap"
+    },
+    {
+        "title": "Shoot to Thrill",
+        "path": "shoot-to-thrill"
+    },
+    {
+        "title": "Rock and Roll Ain't Noise Pollution",
+        "path": "rock-and-roll-aint-noise-pollution"
+    },
+    {
+        "title": "For Those About to Rock (We Salute You)",
+        "path": "for-those-about-to-rock-we-salute-you"
+    }
+]

--- a/cypress/fixtures/artist-songs/guns-n-roses.json
+++ b/cypress/fixtures/artist-songs/guns-n-roses.json
@@ -1,0 +1,42 @@
+[
+    {
+        "title": "Sweet Child O' Mine",
+        "path": "sweet-child-o-mine"
+    },
+    {
+        "title": "November Rain",
+        "path": "november-rain"
+    },
+    {
+        "title": "Welcome to the Jungle",
+        "path": "welcome-to-the-jungle"
+    },
+    {
+        "title": "Paradise City",
+        "path": "paradise-city"
+    },
+    {
+        "title": "Knockin' on Heaven's Door",
+        "path": "knockin-on-heavens-door"
+    },
+    {
+        "title": "Don't Cry",
+        "path": "dont-cry"
+    },
+    {
+        "title": "Civil War",
+        "path": "civil-war"
+    },
+    {
+        "title": "Patience",
+        "path": "patience"
+    },
+    {
+        "title": "You Could Be Mine",
+        "path": "you-could-be-mine"
+    },
+    {
+        "title": "Estranged",
+        "path": "estranged"
+    }
+]

--- a/cypress/fixtures/artist-songs/hillsong-united.json
+++ b/cypress/fixtures/artist-songs/hillsong-united.json
@@ -1,0 +1,295 @@
+
+[
+    {
+        "title": "Oceans (Where Feet May Fail)",
+        "path": "oceans-where-feet-may-fail"
+    },
+    {
+        "title": "So Will I (100 Billion X)",
+        "path": "so-will-i-100-billion-x"
+    },
+    {
+        "title": "I Surrender",
+        "path": "i-surrender"
+    },
+    {
+        "title": "Poder Pra Salvar",
+        "path": "poder-pra-salvar"
+    },
+    {
+        "title": "Yo También (Un Billón de Veces)",
+        "path": "yo-tambien-un-billon-de-veces"
+    },
+    {
+        "title": "Desde Mi Interior",
+        "path": "desde-mi-interior"
+    },
+    {
+        "title": "Océanos (Donde Mis Pies Pueden Fallar)",
+        "path": "oceanos-donde-mis-pies-pueden-fallar"
+    },
+    {
+        "title": "Es Tiempo",
+        "path": "es-tiempo"
+    },
+    {
+        "title": "Tómalo",
+        "path": "tomalo"
+    },
+    {
+        "title": "Hosanna",
+        "path": "hosanna"
+    },
+    {
+        "title": "A beautiful exchange",
+        "path": "a-beautiful-exchange"
+    },
+    {
+        "title": "A Million Suns",
+        "path": "a-million-suns"
+    },
+    {
+        "title": "A Minha Fé",
+        "path": "a-minha-fe"
+    },
+    {
+        "title": "A Reprise",
+        "path": "a-reprise"
+    },
+    {
+        "title": "A Song To Sing",
+        "path": "a-song-to-sing"
+    },
+    {
+        "title": "A Tus Pies",
+        "path": "a-tus-pies"
+    },
+    {
+        "title": "Above All",
+        "path": "above-all"
+    },
+    {
+        "title": "Abra Meus Olhos (open My Eyes)",
+        "path": "abra-meus-olhos-open-my-eyes"
+    },
+    {
+        "title": "Abre los cielos",
+        "path": "abre-los-cielos"
+    },
+    {
+        "title": "Abre mis ojos",
+        "path": "abre-mis-ojos"
+    },
+    {
+        "title": "Abre Mis Ojos Oh Cristo",
+        "path": "abre-mis-ojos-oh-cristo"
+    },
+    {
+        "title": "Acércame a ti",
+        "path": "acercame-a-ti"
+    },
+    {
+        "title": "Across the heart",
+        "path": "across-the-heart"
+    },
+    {
+        "title": "Adonai",
+        "path": "adonai"
+    },
+    {
+        "title": "Aftermath",
+        "path": "aftermath"
+    },
+    {
+        "title": "Age To Age",
+        "path": "age-to-age"
+    },
+    {
+        "title": "Alabare al Señor (anástasis)",
+        "path": "alabare-al-senor-anastasis"
+    },
+    {
+        "title": "Aleluya",
+        "path": "aleluya"
+    },
+    {
+        "title": "Alive In Us",
+        "path": "alive-in-us"
+    },
+    {
+        "title": "All About You",
+        "path": "all-about-you"
+    },
+    {
+        "title": "All About You Live",
+        "path": "all-about-you-live/guitarpro"
+    },
+    {
+        "title": "All day",
+        "path": "all-day"
+    },
+    {
+        "title": "All for love",
+        "path": "all-for-love"
+    },
+    {
+        "title": "All I do",
+        "path": "all-i-do"
+    },
+    {
+        "title": "All I need is You",
+        "path": "all-need-is-you"
+    },
+    {
+        "title": "All In All",
+        "path": "all-in-all"
+    },
+    {
+        "title": "All of my days",
+        "path": "all-of-my-days"
+    },
+    {
+        "title": "All",
+        "path": "all"
+    },
+    {
+        "title": "All the heavens",
+        "path": "all-the-heavens"
+    },
+    {
+        "title": "Altísimo",
+        "path": "altisimo"
+    },
+    {
+        "title": "Always Will",
+        "path": "always-will"
+    },
+    {
+        "title": "Always",
+        "path": "always"
+    },
+    {
+        "title": "Am I To Believe?",
+        "path": "am-to-believe"
+    },
+    {
+        "title": "Am I To Believe",
+        "path": "am-i-to-believe"
+    },
+    {
+        "title": "Amazing Grace (Broken Vessels)",
+        "path": "amazing-grace-broken-vessels"
+    },
+    {
+        "title": "Amazing Love",
+        "path": "amazing-love"
+    },
+    {
+        "title": "Amigos en verdad",
+        "path": "amigos-en-verdad"
+    },
+    {
+        "title": "Amor Como Fuego",
+        "path": "amor-como-fuego"
+    },
+    {
+        "title": "Amor Incrível",
+        "path": "amor-incrivel"
+    },
+    {
+        "title": "Amor Real",
+        "path": "amor-real"
+    },
+    {
+        "title": "Amor sin comparación",
+        "path": "amor-sin-comparacion"
+    },
+    {
+        "title": "An Introduction",
+        "path": "an-introduction"
+    },
+    {
+        "title": "Anclado",
+        "path": "anclado"
+    },
+    {
+        "title": "Another In The Fire",
+        "path": "another-in-the-fire"
+    },
+    {
+        "title": "Aquella Cruz",
+        "path": "aquella-cruz"
+    },
+    {
+        "title": "Aquí Estoy",
+        "path": "aqui-estoy"
+    },
+    {
+        "title": "Aquí Hay Salvación",
+        "path": "aqui-hay-salvacion"
+    },
+    {
+        "title": "Arms Open Wide",
+        "path": "arms-open-wide"
+    },
+    {
+        "title": "As It Is (in Heaven)",
+        "path": "as-it-is-in-heaven"
+    },
+    {
+        "title": "As It Is (In Heaven)",
+        "path": "as-it-is-in-heaven-"
+    },
+    {
+        "title": "As You Find Me",
+        "path": "as-you-find-me"
+    },
+    {
+        "title": "Asombroso Dios",
+        "path": "asombroso-dios"
+    },
+    {
+        "title": "Asombroso",
+        "path": "asombroso"
+    },
+    {
+        "title": "Asombro",
+        "path": "asombro"
+    },
+    {
+        "title": "At The Cross",
+        "path": "at-the-cross"
+    },
+    {
+        "title": "Até Te Ver (till I See You)",
+        "path": "ate-te-ver-till-i-see-you"
+    },
+    {
+        "title": "Aún",
+        "path": "aun"
+    },
+    {
+        "title": "Avivamiento",
+        "path": "avivamiento"
+    },
+    {
+        "title": "Awakening",
+        "path": "awakening"
+    },
+    {
+        "title": "Awesome God",
+        "path": "awesome-god"
+    },
+    {
+        "title": "Beautiful Exchange",
+        "path": "beautiful-exchange"
+    },
+    {
+        "title": "Behold (Then Sings My Soul)",
+        "path": "behold-then-sings-my-soul"
+    },
+    {
+        "title": "Bendito El Que Habita",
+        "path": "bendito-el-que-habita"
+    }
+]

--- a/cypress/fixtures/artist-songs/rosa-de-saron.json
+++ b/cypress/fixtures/artist-songs/rosa-de-saron.json
@@ -1,0 +1,42 @@
+[
+    {
+        "title": "Casa Vazia",
+        "path": "casa-vazia"
+    },
+    {
+        "title": "Sem Você",
+        "path": "sem-voce"
+    },
+    {
+        "title": "Insônia",
+        "path": "insonia"
+    },
+    {
+        "title": "O Sol e a Lua",
+        "path": "o-sol-e-a-lua"
+    },
+    {
+        "title": "Cartas ao Remetente",
+        "path": "cartas-ao-remetente"
+    },
+    {
+        "title": "Horizonte",
+        "path": "horizonte"
+    },
+    {
+        "title": "Rosas",
+        "path": "rosas"
+    },
+    {
+        "title": "Não Existem Coincidências",
+        "path": "nao-existem-coincidencias"
+    },
+    {
+        "title": "Além do Rio Azul",
+        "path": "alem-do-rio-azul"
+    },
+    {
+        "title": "Mesmo Sem Entender",
+        "path": "mesmo-sem-entender"
+    }
+]

--- a/cypress/fixtures/artists.json
+++ b/cypress/fixtures/artists.json
@@ -1,0 +1,22 @@
+[
+  {
+    "path": "hillsong-united",
+    "displayName": "Hillsong United",
+    "songCount": 127
+  },
+  {
+    "path": "ac-dc",
+    "displayName": "AC/DC",
+    "songCount": 95
+  },
+  {
+    "path": "guns-n-roses",
+    "displayName": "Guns N' Roses",
+    "songCount": 150
+  },
+  {
+    "path": "rosa-de-saron",
+    "displayName": "Rosa de Saron",
+    "songCount": 93
+  }
+]

--- a/cypress/fixtures/cifraclub-search.json
+++ b/cypress/fixtures/cifraclub-search.json
@@ -1,0 +1,34 @@
+[
+    {
+        "title": "Wonderful - Luca Hänni",
+        "url": "https://www.cifraclub.com.br/luca-hanni/wonderful/"
+    },
+    {
+        "title": "Wonderful - Aretha Franklin",
+        "url": "https://www.cifraclub.com.br/aretha-franklin/wonderful/"
+    },
+    {
+        "title": "Wonderful - Ja Rule",
+        "url": "https://www.cifraclub.com.br/ja-rule/wonderful/"
+    },
+    {
+        "title": "Wonderful Tonight - Eric Clapton",
+        "url": "https://www.cifraclub.com.br/eric-clapton/wonderful-tonight/"
+    },
+    {
+        "title": "Wonderful Wonderful - The Killers",
+        "url": "https://www.cifraclub.com.br/the-killers/wonderful-wonderful/"
+    },
+    {
+        "title": "Wonderful - Lady Gaga",
+        "url": "https://www.cifraclub.com.br/lady-gaga/wonderful/"
+    },
+    {
+        "title": "Wonderful Life - Imany",
+        "url": "https://www.cifraclub.com.br/imany/wonderful-life/"
+    },
+    {
+        "title": "Wonderful You - Rick Astley",
+        "url": "https://www.cifraclub.com.br/rick-astley/wonderful-you/"
+    }
+]


### PR DESCRIPTION
This pull request adds new song data and artist information to the Cypress fixtures using the response schema to be implemented.

 The changes include the addition of song lists for specific artists, an updated artist list, and new search results for the keyword "Wonderful."

### Song data additions:
* Added a list of 10 songs for `AC/DC` in `cypress/fixtures/artist-songs/ac-dc.json`.
* Added a list of 10 songs for `Guns N' Roses` in `cypress/fixtures/artist-songs/guns-n-roses.json`.
* Added a comprehensive list of 127 songs for `Hillsong United` in `cypress/fixtures/artist-songs/hillsong-united.json`.
* Added a list of 10 songs for `Rosa de Saron` in `cypress/fixtures/artist-songs/rosa-de-saron.json`.

### Artist information updates:
* Added metadata for four artists (`Hillsong United`, `AC/DC`, `Guns N' Roses`, and `Rosa de Saron`) including their paths, display names, and song counts in `cypress/fixtures/artists.json`.

### Search results updates:
* Added search results for the keyword "Wonderful," including songs by artists such as Luca Hänni, Aretha Franklin, Eric Clapton, and others, in `cypress/fixtures/cifraclub-search.json`.