### PR TITLE
fix: song selection by using exact scraped path to fetch chord sheet

### DIFF
--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import SongViewer from "@/components/SongViewer";
 import { useSingleChordSheet } from "@/storage/hooks/use-single-chord-sheet";
 import type { RouteParams } from "./chord-viewer.types";
@@ -7,6 +7,7 @@ import type { RouteParams } from "./chord-viewer.types";
 // Utils
 import { resolveChordSheetPath } from "./utils/path-resolver";
 import { createChordSheetData } from "./utils/chord-sheet-data";
+import { extractNavigationData } from "./utils/navigation-data";
 
 // Hooks
 import { useNavigation } from "@/hooks/navigation";
@@ -23,9 +24,12 @@ import { ChordViewerError } from "./components/chord-viewer-error";
 const ChordViewer = () => {
   const chordDisplayRef = useRef<HTMLDivElement>(null);
   const routeParams = useParams() as RouteParams;
+  const location = useLocation();
 
-  // Convert URL parameters to chord sheet storage path
-  const path = resolveChordSheetPath(routeParams);
+  // Try to get the path from navigation state first (most accurate)
+  // Fall back to URL parameters if navigation state is not available
+  const navigationData = extractNavigationData(location.state);
+  const path = navigationData?.path || resolveChordSheetPath(routeParams);
 
   // Fetch single chord sheet data from IndexedDB
   const chordSheetResult = useSingleChordSheet({ path });

--- a/frontend/src/search/hooks/useSongActions.ts
+++ b/frontend/src/search/hooks/useSongActions.ts
@@ -28,12 +28,10 @@ export const useSongActions = ({
       const currentPath = location.pathname + location.search;
       storeNavigationPath(currentPath);
       
-      // Navigate directly to chord sheet page - no deduplication needed
-      // Search is for discovery, chord sheets are handled separately
-      if (songData.artist && songData.title) {
-        const artistSlug = toSlug(songData.artist);
-        const songSlug = toSlug(songData.title);
-        const targetUrl = `/${artistSlug}/${songSlug}`;
+      // Navigate directly to chord sheet page using the song's path property
+      // This ensures we use the exact path format that the backend expects
+      if (songData.path) {
+        const targetUrl = `/${songData.path}`;
 
         navigate(targetUrl, {
           state: { song: songData },


### PR DESCRIPTION
Addresses #103 .

## Fix: Preserve exact song paths from backend to prevent API call failures

### Problem
When clicking on search results, song paths were being normalized/altered, causing API calls to fail. For example:
- Backend provides: `"oficina-g3/espelhos-magicos-"`
- Frontend was using: `"oficina-g3/espelhos-magicos"` (missing trailing dash)
- API call failed because the path format didn't match backend expectations, or if managing to properly scrape chord sheet, path was normalised before save, preventing getting the correct saved Record from cache.

### Root Cause
1. **URL Navigation**: `useSongActions.handleView()` was constructing URLs by slugifying artist/title instead of using the song's `path` property
2. **API Call**: Chord viewer was reconstructing paths from URL parameters instead of using the original path from navigation state

### Solution
1. **Fixed URL navigation** to use song's exact `path` property from backend
2. **Fixed chord viewer** to prioritize navigation state over URL parameter reconstruction

### Changes
- `frontend/src/search/hooks/useSongActions.ts`: Use `songData.path` directly instead of slugifying artist/title
- `frontend/src/pages/chord-viewer/index.tsx`: Prioritize navigation state path over URL parameter reconstruction
- Updated tests to reflect new behavior

### Result
Song paths now preserve their exact format from backend throughout the entire flow, ensuring API calls work correctly.