### PR TITLE
fix(artist-songs): Puppeteer first, Neon fallback, JSONP last resort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,4 +57,5 @@ npm run clean        # Remove all node_modules and build artifacts
 ## Git Workflow
 
 - NEVER commit without explicit user approval
+- NEVER push directly to main/master — always use a feature branch and let the user merge via PR
 - No Co-Authored-By or Claude attribution in commits

--- a/frontend/api/artist-songs.ts
+++ b/frontend/api/artist-songs.ts
@@ -18,24 +18,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const escapedPath = artistPath.replace(/[%_]/g, "\\$&");
 
-  // Check Neon first
-  try {
-    const { rows } = await sql`
-      SELECT title, artist, path
-      FROM songs
-      WHERE path LIKE ${escapedPath + "/%"}
-      ORDER BY title
-    `;
-    if (rows.length > 0) {
-      // Update songCount in background if it differs
-      sql`UPDATE artists SET "songCount" = ${rows.length} WHERE path = ${artistPath} AND ("songCount" IS NULL OR "songCount" != ${rows.length})`.catch(() => {});
-      return res.json(rows);
-    }
-  } catch {
-    // fall through
-  }
-
-  // Scrape /musicas.html with Puppeteer + @sparticuz/chromium
+  // 1. Puppeteer first — authoritative, seeds Neon
   let browser = null;
   try {
     browser = await puppeteer.launch({
@@ -79,7 +62,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }, artistPath);
 
     if (songs.length > 0) {
-      // Seed Neon in background — songs + update artist songCount
+      // Seed Neon in background — upsert songs + update songCount
       Promise.all([
         ...songs.map((s) =>
           sql`INSERT INTO songs (title, artist, path) VALUES (${s.title}, ${s.artist}, ${s.path}) ON CONFLICT (path) DO NOTHING`.catch(() => {})
@@ -89,12 +72,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.json(songs);
     }
   } catch {
-    // fall through to JSONP
+    // Puppeteer failed — fall through to Neon cache
   } finally {
     if (browser) await browser.close().catch(() => {});
   }
 
-  // JSONP fallback — limited to ~5 songs
+  // 2. Neon cache — fallback when Puppeteer fails
+  try {
+    const { rows } = await sql`
+      SELECT title, artist, path
+      FROM songs
+      WHERE path LIKE ${escapedPath + "/%"}
+      ORDER BY title
+    `;
+    if (rows.length > 0) {
+      return res.json(rows);
+    }
+  } catch {
+    // fall through to JSONP
+  }
+
+  // 3. JSONP last resort
   try {
     const docs = await fetchJsonpDocs(artistPath.replace(/-/g, " "));
     const songs = docs


### PR DESCRIPTION
## Summary

- Puppeteer (`/musicas.html`) is now the primary source for artist song lists — always fetched first for authoritative, up-to-date results
- Neon DB is fallback if Puppeteer fails (cold start, timeout, etc.)
- JSONP is last resort if both fail
- Fixes artists that were \"poisoned\" by JSONP with only 1–5 songs in the DB

## Why

Previous order (Neon first) meant artists seeded by JSONP with partial results would never get refreshed. Puppeteer first ensures the DB always gets the full list.