### PR TITLE
feat(chord-metadata): turn artist badge into search link

### DIFF
--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import MetadataBadge from "./MetadataBadge";
 import type { ChordMetadataProps } from "./ChordMetadata.types";
+import { normalizeNamePart } from "@/utils/chord-sheet-path";
 
 const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet }) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const tuning = chordSheet.guitarTuning
     ? Array.isArray(chordSheet.guitarTuning)
@@ -17,11 +20,20 @@ const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet }) => {
       ? chordSheet.guitarCapo.toString()
       : t("chordMetadata.none");
 
+  const handleArtistClick = () => {
+    if (chordSheet.artist) {
+      const artistPath = `/${normalizeNamePart(chordSheet.artist)}`;
+      navigate(artistPath);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-1 p-0 sm:grid sm:[grid-template-columns:repeat(4,_min-content)] sm:gap-x-4 sm:gap-y-1 sm:justify-between sm:px-4 sm:py-3 w-full text-xs">
       <MetadataBadge
         label={t("chordMetadata.artist")}
         value={chordSheet.artist || t("chordMetadata.unknown")}
+        onClick={chordSheet.artist ? handleArtistClick : undefined}
+        isClickable={!!chordSheet.artist}
       />
       <div className="flex gap-3 whitespace-nowrap sm:contents">
         <MetadataBadge

--- a/frontend/src/components/ChordDisplay/ChordMetadata/MetadataBadge.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/MetadataBadge.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 import type { MetadataBadgeProps } from "./MetadataBadge.types";
 
-const MetadataBadge: React.FC<MetadataBadgeProps> = ({ label, value, truncate }) => {
+const MetadataBadge: React.FC<MetadataBadgeProps> = ({ label, value, truncate, onClick, isClickable }) => {
   if (truncate) {
     return (
       <div className="flex overflow-hidden w-full">
         <span className="font-medium text-muted-foreground whitespace-nowrap shrink-0">{label}</span>
-        <span className="ml-2 font-medium text-chord-dark dark:text-primary/80 truncate">{value}</span>
+        <span
+          className={`ml-2 font-medium text-chord-dark dark:text-primary/80 truncate ${isClickable ? 'cursor-pointer hover:underline' : ''}`}
+          onClick={onClick}
+          role={isClickable ? "button" : undefined}
+          tabIndex={isClickable ? 0 : undefined}
+          onKeyDown={isClickable ? (e) => e.key === 'Enter' && onClick?.() : undefined}
+        >
+          {value}
+        </span>
       </div>
     );
   }
@@ -14,7 +22,15 @@ const MetadataBadge: React.FC<MetadataBadgeProps> = ({ label, value, truncate })
   return (
     <div className="whitespace-nowrap">
       <span className="font-medium text-muted-foreground">{label}</span>
-      <span className="ml-2 font-medium text-chord-dark dark:text-primary/80">{value}</span>
+      <span
+        className={`ml-2 font-medium text-chord-dark dark:text-primary/80 ${isClickable ? 'cursor-pointer hover:underline' : ''}`}
+        onClick={onClick}
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        onKeyDown={isClickable ? (e) => e.key === 'Enter' && onClick?.() : undefined}
+      >
+        {value}
+      </span>
     </div>
   );
 };

--- a/frontend/src/components/ChordDisplay/ChordMetadata/MetadataBadge.types.ts
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/MetadataBadge.types.ts
@@ -2,4 +2,6 @@ export interface MetadataBadgeProps {
   label: string;
   value: string;
   truncate?: boolean;
+  onClick?: () => void;
+  isClickable?: boolean;
 }


### PR DESCRIPTION
Turns the Artist badge in the chord sheet metadata into a clickable link redirecting to a search for that artist's songs