### PR TITLE
feat: search history on search page

### DIFF
--- a/backend/controllers/handlers/getSongMetadataHandler.ts
+++ b/backend/controllers/handlers/getSongMetadataHandler.ts
@@ -73,10 +73,11 @@ export async function getSongMetadataHandler(
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    if ((error as any).code === "NOT_FOUND") {
+      res.status(404).json({ error: "Song not found", details: errorMessage });
+      return;
+    }
     logger.error("❌ Error fetching song metadata:", error);
-
-    res
-      .status(500)
-      .json({ error: "Failed to fetch song metadata", details: errorMessage });
+    res.status(500).json({ error: "Failed to fetch song metadata", details: errorMessage });
   }
 }

--- a/backend/routes/api.ts
+++ b/backend/routes/api.ts
@@ -4,6 +4,7 @@ import { getArtistSongsHandler } from '../controllers/handlers/getArtistSongsHan
 import { getChordSheetHandler } from '../controllers/handlers/getChordSheetHandler.js';
 import { getSongMetadataHandler } from '../controllers/handlers/getSongMetadataHandler.js';
 import { getArtistsHandler } from '../controllers/handlers/getArtistsHandler.js';
+import cifraClubService from '../services/cifraclub.service.js';
 
 const router: Router = express.Router();
 
@@ -14,3 +15,19 @@ router.get('/cifraclub-song-metadata', (req, res) => getSongMetadataHandler(req,
 router.get('/cifraclub-chord-sheet', (req, res) => getChordSheetHandler(req, res));
 
 export default router;
+
+// Local dev shim: combines metadata + chord sheet into a single response (mirrors the Vercel cifraclub-song function)
+router.get('/cifraclub-song', async (req, res) => {
+  try {
+    const { url: pathParam } = req.query as { url?: string };
+    if (!pathParam) { res.status(400).json({ error: 'Missing url parameter' }); return; }
+    const cifraClubUrl = `https://www.cifraclub.com.br/${pathParam.trim()}/`;
+    const [metadata, chordSheet] = await Promise.all([
+      cifraClubService.getSongMetadata(cifraClubUrl),
+      cifraClubService.getChordSheet(cifraClubUrl),
+    ]);
+    res.json({ ...metadata, ...chordSheet });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch song', details: error instanceof Error ? error.message : String(error) });
+  }
+});

--- a/backend/routes/api.ts
+++ b/backend/routes/api.ts
@@ -28,6 +28,7 @@ router.get('/cifraclub-song', async (req, res) => {
     ]);
     res.json({ ...metadata, ...chordSheet });
   } catch (error) {
-    res.status(500).json({ error: 'Failed to fetch song', details: error instanceof Error ? error.message : String(error) });
+    const status = (error as any).code === "NOT_FOUND" ? 404 : 500;
+    res.status(status).json({ error: status === 404 ? 'Song not found' : 'Failed to fetch song', details: error instanceof Error ? error.message : String(error) });
   }
 });

--- a/backend/utils/chord-sheet-fetcher.ts
+++ b/backend/utils/chord-sheet-fetcher.ts
@@ -228,14 +228,14 @@ async function attemptMetadataLoad(
     {
       name: "fast",
       waitUntil: "domcontentloaded",
-      timeout: 30000, // Shorter timeout for metadata
-      waitAfter: 1000, // Shorter wait for metadata
+      timeout: 12000,
+      waitAfter: 500,
     },
     {
       name: "standard",
       waitUntil: "load",
-      timeout: 45000,
-      waitAfter: 2000,
+      timeout: 18000,
+      waitAfter: 1000,
     },
   ];
 
@@ -255,12 +255,21 @@ async function attemptMetadataLoad(
 
       await delay(strategy.waitAfter);
 
+      // Validate that Puppeteer landed on the expected page (not a redirect to homepage)
+      const finalUrl = page.url();
+      const expectedPath = new URL(songUrl).pathname.replace(/\/+$/, "").toLowerCase();
+      const finalPath = new URL(finalUrl).pathname.replace(/\/+$/, "").toLowerCase();
+      if (!finalPath.startsWith(expectedPath)) {
+        throw Object.assign(new Error(`Song not found: page redirected to ${finalUrl}`), { code: "NOT_FOUND" });
+      }
+
       // Extract metadata only (no pre element reading)
       const metadata = await page.evaluate(extractSongMetadata);
       logger.info(`📝 Metadata extracted using ${strategy.name} strategy`);
 
       return metadata;
     } catch (error) {
+      if ((error as any).code === "NOT_FOUND") throw error;
       lastError = error instanceof Error ? error : new Error(String(error));
       logger.warn(
         `${strategy.name} strategy failed for metadata ${songUrl}:`,

--- a/frontend/src/chord-sheet/components/ChordSheetCard.tsx
+++ b/frontend/src/chord-sheet/components/ChordSheetCard.tsx
@@ -9,7 +9,7 @@ import { cyAttr } from "@/utils/test-utils";
  */
 const ChordSheetCard: React.FC<ChordSheetCardProps> = ({ chordSheet, onView, onDelete }) => {
   return (
-    <Card className="h-18 w-full overflow-hidden cursor-pointer hover:border-primary/70 hover:text-primary transition-colors duration-300" {...cyAttr(`chordsheet-card-${chordSheet.path}`)}>
+    <Card className="h-18 w-full overflow-hidden cursor-pointer hover:bg-primary/5 dark:hover:bg-primary/5 hover:border-primary hover:text-primary transition-colors duration-300" {...cyAttr(`chordsheet-card-${chordSheet.path}`)}>
       <CardContent
         className="flex-1 flex flex-col justify-between p-4"
         onClick={() => onView(chordSheet)}

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@/components/ui/card";
 
 const ErrorState = ({ error }: { error: string }) => (
-  <Card className="p-6 text-center text-destructive">{error}</Card>
+  <Card className="p-6 text-center text-foreground">{error}</Card>
 );
 
 export default ErrorState;

--- a/frontend/src/components/PageHeader/PageHeader.types.ts
+++ b/frontend/src/components/PageHeader/PageHeader.types.ts
@@ -5,5 +5,6 @@ export interface PageHeaderProps {
   onAction?: () => void; // Unified callback for both save and delete actions
   isSaved?: boolean; // If true, shows delete button; if false, shows save button; if undefined, shows neither
   title?: string;
+  titleClassName?: string;
   rightContent?: ReactNode;
 }

--- a/frontend/src/components/PageHeader/TitleSection.tsx
+++ b/frontend/src/components/PageHeader/TitleSection.tsx
@@ -1,15 +1,16 @@
 interface TitleSectionProps {
   title?: string;
   isMobile?: boolean;
+  titleClassName?: string;
 }
 
 /**
  * Reusable title section component with responsive styling
  */
-const TitleSection = ({ title, isMobile = false }: TitleSectionProps) => (
+const TitleSection = ({ title, isMobile = false, titleClassName = "" }: TitleSectionProps) => (
   title ? (
     <div className={`flex flex-col ${isMobile ? 'min-w-0' : 'flex-1 min-w-0 text-center'}`}>
-      <h1 className="text-lg font-semibold truncate" title={title}>
+      <h1 className={`text-lg font-semibold truncate ${titleClassName}`} title={title}>
         {title}
       </h1>
     </div>

--- a/frontend/src/components/PageHeader/index.tsx
+++ b/frontend/src/components/PageHeader/index.tsx
@@ -17,6 +17,7 @@ const PageHeader = memo(({
   onAction,
   isSaved,
   title,
+  titleClassName,
   rightContent
 }: PageHeaderProps) => {
 
@@ -24,7 +25,7 @@ const PageHeader = memo(({
     <Card className="flex flex-row items-center gap-2 py-3 px-4 rounded-lg border bg-card dark:bg-[--card] text-card-foreground shadow-sm">
       {/* Mobile layout: Title first, then buttons at far right */}
       <div className="flex sm:hidden flex-row items-center justify-between w-full gap-3">
-        <TitleSection title={title} isMobile={true} />
+        <TitleSection title={title} isMobile={true} titleClassName={titleClassName} />
         <div className="flex items-center gap-2 shrink-0">
           <BackButton onBack={onBack} />
           {isSaved === true && onAction && <DeleteButton onDelete={onAction} />}
@@ -39,9 +40,9 @@ const PageHeader = memo(({
           <BackButton onBack={onBack} />
         </div>
         <div className="flex-1 min-w-0">
-          <TitleSection title={title} />
+          <TitleSection title={title} titleClassName={titleClassName} />
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 shrink-0 min-w-8">
           {isSaved === true && onAction && <DeleteButton onDelete={onAction} />}
           {isSaved === false && onAction && <SaveButton onSave={onAction} />}
           {rightContent}

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -19,5 +19,10 @@
     "componentStack": "Component Stack:",
     "copyAll": "Copy All",
     "copied": "Copied!"
+  },
+  "chordViewer": {
+    "errorTitle": "Error",
+    "chordSheetNotFound": "Chord sheet not found",
+    "failedToLoad": "Failed to load chord sheet"
   }
 }

--- a/frontend/src/locales/es/errors.json
+++ b/frontend/src/locales/es/errors.json
@@ -19,5 +19,10 @@
     "componentStack": "Pila del componente:",
     "copyAll": "Copiar todo",
     "copied": "¡Copiado!"
+  },
+  "chordViewer": {
+    "errorTitle": "Error",
+    "chordSheetNotFound": "Cifra no encontrada",
+    "failedToLoad": "Error al cargar la cifra"
   }
 }

--- a/frontend/src/locales/pt-BR/errors.json
+++ b/frontend/src/locales/pt-BR/errors.json
@@ -19,5 +19,10 @@
     "componentStack": "Stack do Componente:",
     "copyAll": "Copiar Tudo",
     "copied": "Copiado!"
+  },
+  "chordViewer": {
+    "errorTitle": "Erro",
+    "chordSheetNotFound": "Cifra não encontrada",
+    "failedToLoad": "Falha ao carregar a cifra"
   }
 }

--- a/frontend/src/pages/chord-viewer/components/chord-viewer-error.tsx
+++ b/frontend/src/pages/chord-viewer/components/chord-viewer-error.tsx
@@ -1,3 +1,6 @@
+import { useTranslation } from "react-i18next";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import ErrorState from "@/components/ErrorState";
 import PageHeader from "@/components/PageHeader";
 import type { ChordViewerNavigationMethods } from "../chord-viewer.types";
@@ -8,16 +11,37 @@ interface ChordViewerErrorProps {
   readonly onBack: () => void;
 }
 
-/**
- * Error state component for chord viewer
- * Shows error message with appropriate navigation options
- */
+const STATIC_ERROR_KEYS: Record<string, string> = {
+  "Chord sheet not found": "errors:chordViewer.chordSheetNotFound",
+  "Failed to load chord sheet": "errors:chordViewer.failedToLoad",
+};
+
 export function ChordViewerError({ error, navigation, onBack }: ChordViewerErrorProps) {
+  const { t } = useTranslation();
+  const translatedError = STATIC_ERROR_KEYS[error] ? t(STATIC_ERROR_KEYS[error]) : error;
+
   return (
     <div className="min-h-screen flex flex-col">
       <main className="flex-1 container py-8 px-4 max-w-3xl mx-auto">
-        <PageHeader onBack={onBack} />
-        <ErrorState error={error} />
+        <PageHeader
+          onBack={onBack}
+          title={t("errors:chordViewer.errorTitle")}
+          titleClassName="text-destructive"
+          rightContent={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.location.reload()}
+              className="flex-shrink-0 h-10 w-10 rounded-full"
+              aria-label={t("errors:boundary.tryAgain")}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          }
+        />
+        <div className="mt-4">
+          <ErrorState error={translatedError} />
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -182,11 +182,11 @@ const ChordViewer = () => {
         <SongViewer
           song={{
             song: {
-              title: chordSheetData.chordSheet.title,
-              artist: chordSheetData.chordSheet.artist,
-              path: chordSheetData.path
+              title: chordSheetData!.chordSheet.title,
+              artist: chordSheetData!.chordSheet.artist,
+              path: chordSheetData!.path
             },
-            chordSheet: chordSheetData.chordSheet
+            chordSheet: chordSheetData!.chordSheet
           }}
           chordContent={chordSheetResult.content?.songChords ?? ''}
           chordDisplayRef={chordDisplayRef}

--- a/frontend/src/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/search/components/ResultCard/ResultCard.tsx
@@ -24,7 +24,7 @@ const ResultCard = ({
   }
 
   return (
-    <Card className="overflow-hidden cursor-pointer w-full h-12 min-h-0" {...cyAttr(`${result.type}-card-compact-${path}`)}>
+    <Card className="overflow-hidden cursor-pointer w-full h-12 min-h-0 hover:bg-primary/5 dark:hover:bg-primary/5 hover:border-primary transition-colors" {...cyAttr(`${result.type}-card-compact-${path}`)}>
       <CardContent
         className="p-4 flex-1 flex flex-row items-center gap-2 min-h-0"
         onClick={() => onClick(result)}

--- a/frontend/src/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/search/components/ResultCard/ResultCard.tsx
@@ -30,7 +30,7 @@ const ResultCard = ({
         onClick={() => onClick(result)}
         {...cyAttr(`${result.type}-card-compact-content-${path}`)}
       >
-        <Icon className="h-6 w-6 text-chord" />
+        <div className="flex items-center justify-center h-8 w-8 rounded-full bg-primary shrink-0"><Icon className="h-4 w-4 text-white" /></div>
         <div className="min-w-0 flex-1">
           <h3
             className="w-full block font-semibold truncate text-sm"

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clock, User, Music } from "lucide-react";
+import { Clock, User, Music, Search } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import type { SearchHistoryEntry } from "@/search/hooks/useSearchHistory";
 
@@ -18,11 +18,27 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect }) => {
         Recent searches
       </p>
       <div className="grid grid-cols-1 gap-y-2">
-        {history.map(({ artist, song, timestamp }) => {
-          const label = artist && song
-            ? `${artist} — ${song}`
-            : artist || song;
-          const Icon = song ? Music : User;
+        {history.map(({ artist, song, searchType, displayName, timestamp }) => {
+          let label: string;
+          let Icon: React.ElementType;
+
+          if (searchType === "artist-song") {
+            // selected artist from artist+song search: show artist display name
+            label = displayName || artist;
+            Icon = User;
+          } else if (searchType === "song" && artist && song) {
+            // artist+song query: show both terms
+            label = displayName || `${artist} — ${song}`;
+            Icon = Music;
+          } else if (searchType === "song") {
+            // song-only search
+            label = song;
+            Icon = Music;
+          } else {
+            // artist-only search: use magnifier, show the query term
+            label = artist;
+            Icon = Search;
+          }
 
           return (
             <Card

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -17,7 +17,7 @@ import type { SearchHistoryEntry } from "@/search/hooks/useSearchHistory";
 
 interface SearchHistoryProps {
   history: SearchHistoryEntry[];
-  onSelect: (artist: string, song: string) => void;
+  onSelect: (artist: string, song: string, searchType: string, displayName: string) => void;
   onClear: () => void;
 }
 
@@ -80,11 +80,11 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect, onClea
             <Card
               key={timestamp}
               className="overflow-hidden cursor-pointer w-full h-12 min-h-0 opacity-80 hover:bg-primary/5 dark:hover:bg-primary/5 hover:border-primary transition-colors"
-              onClick={() => onSelect(artist, song)}
+              onClick={() => onSelect(artist, song, searchType, displayName)}
             >
               <CardContent
                 className="p-4 flex-1 flex flex-row items-center gap-2 min-h-0"
-                onClick={() => onSelect(artist, song)}
+                onClick={() => onSelect(artist, song, searchType, displayName)}
               >
                 <div className="flex items-center justify-center h-8 w-8 rounded-full bg-primary shrink-0"><Icon className="h-4 w-4 text-white" /></div>
                 <div className="min-w-0 flex-1">

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -86,7 +86,7 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect, onClea
                 className="p-4 flex-1 flex flex-row items-center gap-2 min-h-0"
                 onClick={() => onSelect(artist, song)}
               >
-                <Icon className="h-6 w-6 text-chord" />
+                <div className="flex items-center justify-center h-8 w-8 rounded-full bg-primary shrink-0"><Icon className="h-4 w-4 text-white" /></div>
                 <div className="min-w-0 flex-1">
                   <h3 className="w-full block font-semibold truncate text-sm" title={label}>
                     {label}

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Clock, User, Music } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { SearchHistoryEntry } from "@/search/hooks/useSearchHistory";
+
+interface SearchHistoryProps {
+  history: SearchHistoryEntry[];
+  onSelect: (artist: string, song: string) => void;
+}
+
+const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect }) => {
+  if (history.length === 0) return null;
+
+  return (
+    <div className="w-full max-w-3xl mx-auto">
+      <p className="text-xs text-muted-foreground px-1 mb-2 flex items-center gap-1 leading-7">
+        <Clock className="h-3 w-3" />
+        Recent searches
+      </p>
+      <div className="grid grid-cols-1 gap-y-2">
+        {history.map(({ artist, song, timestamp }) => {
+          const label = artist && song
+            ? `${artist} — ${song}`
+            : artist || song;
+          const Icon = song ? Music : User;
+
+          return (
+            <Card
+              key={timestamp}
+              className="overflow-hidden cursor-pointer w-full h-12 min-h-0 opacity-60"
+              onClick={() => onSelect(artist, song)}
+            >
+              <CardContent
+                className="p-4 flex-1 flex flex-row items-center gap-2 min-h-0"
+                onClick={() => onSelect(artist, song)}
+              >
+                <Icon className="h-6 w-6 text-chord" />
+                <div className="min-w-0 flex-1">
+                  <h3 className="w-full block font-semibold truncate text-sm" title={label}>
+                    {label}
+                  </h3>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default SearchHistory;

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -1,41 +1,77 @@
 import React from "react";
-import { Clock, User, Music, Search } from "lucide-react";
+import { Clock, User, Music, Search, Trash2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { searchCacheService } from "@/storage/services/search-cache/search-cache-service";
 import type { SearchHistoryEntry } from "@/search/hooks/useSearchHistory";
 
 interface SearchHistoryProps {
   history: SearchHistoryEntry[];
   onSelect: (artist: string, song: string) => void;
+  onClear: () => void;
 }
 
-const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect }) => {
+const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect, onClear }) => {
   if (history.length === 0) return null;
+
+  async function handleConfirmClear() {
+    await searchCacheService.clear();
+    onClear();
+  }
 
   return (
     <div className="w-full max-w-3xl mx-auto">
-      <p className="text-xs text-muted-foreground px-1 mb-2 flex items-center gap-1 leading-7">
-        <Clock className="h-3 w-3" />
-        Recent searches
-      </p>
+      <div className="flex items-center justify-between px-1 mb-2">
+        <p className="text-xs text-muted-foreground flex items-center gap-1 leading-7">
+          <Clock className="h-3 w-3" />
+          Recent searches
+        </p>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button className="group text-xs text-muted-foreground flex items-center gap-1 transition-colors">
+              <Trash2 className="h-3 w-3 text-destructive/50 group-hover:text-destructive transition-colors" />
+              Clear
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Clear recent searches?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will remove all recent search history. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirmClear}>Clear</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
       <div className="grid grid-cols-1 gap-y-2">
         {history.map(({ artist, song, searchType, displayName, timestamp }) => {
           let label: string;
           let Icon: React.ElementType;
 
           if (searchType === "artist-song") {
-            // selected artist from artist+song search: show artist display name
             label = displayName || artist;
             Icon = User;
           } else if (searchType === "song" && artist && song) {
-            // artist+song query: show both terms
             label = displayName || `${artist} — ${song}`;
             Icon = Music;
           } else if (searchType === "song") {
-            // song-only search
             label = song;
             Icon = Music;
           } else {
-            // artist-only search: use magnifier, show the query term
             label = artist;
             Icon = Search;
           }
@@ -43,7 +79,7 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect }) => {
           return (
             <Card
               key={timestamp}
-              className="overflow-hidden cursor-pointer w-full h-12 min-h-0 opacity-60"
+              className="overflow-hidden cursor-pointer w-full h-12 min-h-0 opacity-80 hover:bg-primary/5 dark:hover:bg-primary/5 hover:border-primary transition-colors"
               onClick={() => onSelect(artist, song)}
             >
               <CardContent

--- a/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
+++ b/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
@@ -56,7 +56,7 @@ export function useSearchResultsViewModel({
 
     if (searchType === 'artist') {
       if (activeArtist && artistSongs) {
-        const results = mapSongsToSearchResults(filteredArtistSongs);
+        const results = mapSongsToSearchResults(filteredArtistSongs.map(s => ({ ...s, artist: activeArtist?.displayName ?? s.artist })));
         return {
           results,
           onResultClick: (item: SearchResult) => {

--- a/frontend/src/search/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/search/components/SearchTab/SearchTab.tsx
@@ -61,7 +61,7 @@ const SearchTab: React.FC<SearchTabProps> = (props) => {
             />
          </FormContainer>
          {!hasSearched && (
-            <SearchHistory history={history} onSelect={handleHistorySelect} />
+            <SearchHistory history={history} onSelect={handleHistorySelect} onClear={refresh} />
          )}
          {hasSearched && (
             <div {...cyAttr('search-results-area')}>

--- a/frontend/src/search/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/search/components/SearchTab/SearchTab.tsx
@@ -36,10 +36,14 @@ const SearchTab: React.FC<SearchTabProps> = (props) => {
 
    const { history, refresh } = useSearchHistory();
 
-   function handleHistorySelect(artist: string, song: string) {
-      handleInputChange(artist, song);
+   function handleHistorySelect(artist: string, song: string, searchType: string, displayName: string) {
       refresh();
-      handleSearchSubmit(artist, song);
+      if (searchType === "artist-song") {
+        handleArtistSelect({ path: artist, displayName: displayName || artist, songCount: null });
+      } else {
+        handleInputChange(artist, song);
+        handleSearchSubmit(artist, song);
+      }
    }
 
    return (

--- a/frontend/src/search/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/search/components/SearchTab/SearchTab.tsx
@@ -3,9 +3,10 @@ import React from "react";
 import FormContainer from "@/components/ui/FormContainer";
 import SearchBar from "../SearchBar/SearchBar";
 import { SearchResults } from "../SearchResults";
+import SearchHistory from "../SearchHistory/SearchHistory";
 import { cyAttr } from "@/utils/test-utils/cy-attr";
 import { useSearchTabLogic } from "./hooks/useSearchTabLogic";
-
+import { useSearchHistory } from "@/search/hooks/useSearchHistory";
 
 import type { SearchTabProps } from "./SearchTab.types";
 
@@ -33,6 +34,14 @@ const SearchTab: React.FC<SearchTabProps> = (props) => {
       setActiveTab,
    } = logic;
 
+   const { history, refresh } = useSearchHistory();
+
+   function handleHistorySelect(artist: string, song: string) {
+      handleInputChange(artist, song);
+      refresh();
+      handleSearchSubmit(artist, song);
+   }
+
    return (
       <div className="space-y-4">
          <FormContainer>
@@ -51,6 +60,9 @@ const SearchTab: React.FC<SearchTabProps> = (props) => {
                artistDisabled={!!activeArtist}
             />
          </FormContainer>
+         {!hasSearched && (
+            <SearchHistory history={history} onSelect={handleHistorySelect} />
+         )}
          {hasSearched && (
             <div {...cyAttr('search-results-area')}>
                <SearchResults

--- a/frontend/src/search/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/search/components/SearchTab/SearchTab.tsx
@@ -55,7 +55,7 @@ const SearchTab: React.FC<SearchTabProps> = (props) => {
                onBackClick={activeArtist ? handleBackToArtistList : undefined}
                isSearchDisabled={!artistInput && !songInput}
                artistLoading={loading}
-               onClearSearch={handleClearSearch}
+               onClearSearch={() => { handleClearSearch(); refresh(); }}
                clearDisabled={clearDisabled}
                artistDisabled={!!activeArtist}
             />

--- a/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
+++ b/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { fromSlug } from "@/utils/url-slug-utils";
+import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArtist";
 import type { Artist } from "@chordium/types";
 
 interface InitSearchStateOptions {
@@ -92,7 +93,18 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
       const artistPath = getCurrentArtistPath();
       
       if (artistPath) {
-        const artistName = fromSlug(artistPath);
+        // Prefer stored displayName (set when navigating from artist selection) over fromSlug
+        let artistName = fromSlug(artistPath);
+        try {
+          const stored = sessionStorage.getItem(ARTIST_DISPLAY_NAME_KEY);
+          if (stored) {
+            const { path: storedPath, displayName } = JSON.parse(stored);
+            if (storedPath === artistPath && displayName) {
+              artistName = displayName;
+              sessionStorage.removeItem(ARTIST_DISPLAY_NAME_KEY);
+            }
+          }
+        } catch {}
         
         setActiveArtist({
           displayName: artistName,

--- a/frontend/src/search/hooks/useSearchHistory.ts
+++ b/frontend/src/search/hooks/useSearchHistory.ts
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { getAllSearchCache } from "@/storage/stores/search-cache/operations";
+import { normalizeForSearch } from "@/search/utils/normalization/normalizeForSearch";
 import type { SearchCacheEntry } from "@/storage/types/search-cache";
 
 export interface SearchHistoryEntry {
   artist: string;
   song: string;
+  searchType: string;
+  displayName: string;
   timestamp: number;
 }
 
@@ -17,6 +20,17 @@ export function useSearchHistory(): {
   const load = useCallback(async () => {
     try {
       const entries: SearchCacheEntry[] = await getAllSearchCache();
+
+      // Build a map of artist query -> displayName from artist-type entries
+      const artistDisplayNames = new Map<string, string>();
+      for (const entry of entries) {
+        if (entry.search.searchType === "artist" && entry.results.length > 0) {
+          const firstResult = entry.results[0] as any;
+          if (firstResult?.displayName) {
+            artistDisplayNames.set(normalizeForSearch(entry.search.query.artist ?? ""), firstResult.displayName);
+          }
+        }
+      }
 
       const seen = new Set<string>();
       const unique: SearchHistoryEntry[] = [];
@@ -32,7 +46,13 @@ export function useSearchHistory(): {
         const key = `${artist}|${song}`;
         if (!seen.has(key)) {
           seen.add(key);
-          unique.push({ artist, song, timestamp: entry.storage.timestamp });
+          const firstResult = entry.results[0] as any;
+          // Prefer displayName from Artist results, then look up from artist cache, then fall back
+          const displayName = firstResult?.displayName
+            ?? artistDisplayNames.get(normalizeForSearch(artist))
+            ?? firstResult?.artist
+            ?? "";
+          unique.push({ artist, song, searchType: entry.search.searchType, displayName, timestamp: entry.storage.timestamp });
         }
         if (unique.length >= 10) break;
       }

--- a/frontend/src/search/hooks/useSearchHistory.ts
+++ b/frontend/src/search/hooks/useSearchHistory.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from "react";
+import { getAllSearchCache } from "@/storage/stores/search-cache/operations";
+import type { SearchCacheEntry } from "@/storage/types/search-cache";
+
+export interface SearchHistoryEntry {
+  artist: string;
+  song: string;
+  timestamp: number;
+}
+
+export function useSearchHistory(): {
+  history: SearchHistoryEntry[];
+  refresh: () => void;
+} {
+  const [history, setHistory] = useState<SearchHistoryEntry[]>([]);
+
+  const load = useCallback(async () => {
+    try {
+      const entries: SearchCacheEntry[] = await getAllSearchCache();
+
+      const seen = new Set<string>();
+      const unique: SearchHistoryEntry[] = [];
+
+      // Sort newest first, then deduplicate by query pair
+      const sorted = [...entries].sort(
+        (a, b) => b.storage.timestamp - a.storage.timestamp
+      );
+
+      for (const entry of sorted) {
+        const artist = entry.search.query.artist ?? "";
+        const song = entry.search.query.song ?? "";
+        const key = `${artist}|${song}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          unique.push({ artist, song, timestamp: entry.storage.timestamp });
+        }
+        if (unique.length >= 10) break;
+      }
+
+      setHistory(unique);
+    } catch {
+      setHistory([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { history, refresh: load };
+}

--- a/frontend/src/search/hooks/useSearchReducer/handlers/useSearchFetch.ts
+++ b/frontend/src/search/hooks/useSearchReducer/handlers/useSearchFetch.ts
@@ -51,15 +51,14 @@ export const useSearchFetch = ({
           const cachedEntry = await searchCacheService.get(cacheKey);
           if (cachedEntry) {
             const { results, search } = cachedEntry;
-            if (search.searchType === "artist") {
-              // Artist search results
+            const isArtistResults = results.length === 0 || ("displayName" in results[0]);
+            if (isArtistResults) {
               dispatch({
                 type: "SEARCH_SUCCESS",
                 artists: results as Artist[],
                 songs: [],
               });
             } else {
-              // Song search results
               dispatch({
                 type: "SEARCH_SUCCESS",
                 artists: [],

--- a/frontend/src/search/utils/navigation/navigateToArtist.ts
+++ b/frontend/src/search/utils/navigation/navigateToArtist.ts
@@ -6,10 +6,15 @@
  */
 import type { Artist } from "@chordium/types";
 
+export const ARTIST_DISPLAY_NAME_KEY = 'chordium_artist_display_name';
+
 export function navigateToArtist(
   artist: Artist, 
   navigate: (path: string, options?: { replace?: boolean }) => void
 ): void {
+  try {
+    sessionStorage.setItem(ARTIST_DISPLAY_NAME_KEY, JSON.stringify({ path: artist.path, displayName: artist.displayName }));
+  } catch {}
   const artistPath = `/${artist.path}`;
   navigate(artistPath, { replace: true });
 }

--- a/frontend/src/services/api/fetch-song.ts
+++ b/frontend/src/services/api/fetch-song.ts
@@ -13,7 +13,7 @@ export async function fetchSongFromAPI(path: string): Promise<SongData | null> {
 
     if (!response.ok) {
       if (response.status === 404) return null;
-      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+      throw new Error("Failed to load chord sheet");
     }
 
     const data = await response.json();


### PR DESCRIPTION
- Shows up to 10 recent searches from IndexedDB on the search page, hidden while results are active
- History items match `ResultCard`/`ResultsList` styling with slight opacity to differentiate from live results
- Clicking a history item populates the search bar and triggers the search