### PR TITLE
fix: artist badge navigation, correct sample paths, and ARM Puppeteer support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,8 @@ npm run clean        # Remove all node_modules and build artifacts
 - NEVER commit without explicit user approval
 - NEVER push directly to main/master — always use a feature branch and let the user merge via PR
 - No Co-Authored-By or Claude attribution in commits
+
+## Local Development Notes
+
+- **Search requires both frontend and backend running.** The frontend alone is not enough — search, artist songs, and chord sheet fetching all proxy through the Express backend on port 3001. Always run `npm run dev` (or `npm run dev:fe` + `npm run dev:be` in separate terminals) when working on search-related features.
+- Frontend runs on port 8080 (falls back to 8081 if taken), backend on port 3001.

--- a/backend/config/config.ts
+++ b/backend/config/config.ts
@@ -63,7 +63,8 @@ function createConfig(): Config {
       ],
       keepAlive: 10 * 60 * 1000, // 10 minutes
       maxRetries: 3,
-      retryDelay: 2000
+      retryDelay: 2000,
+      ...(process.env.PUPPETEER_EXECUTABLE_PATH ? { executablePath: process.env.PUPPETEER_EXECUTABLE_PATH } : {})
     },
 
     // CifraClub specific

--- a/backend/services/puppeteer.service.ts
+++ b/backend/services/puppeteer.service.ts
@@ -49,7 +49,8 @@ class PuppeteerService {
 
     this.browser = await puppeteer.launch({
       headless: config.puppeteer.headless,
-      args: config.puppeteer.args
+      args: config.puppeteer.args,
+      ...(config.puppeteer.executablePath ? { executablePath: config.puppeteer.executablePath } : {})
     });
     
     this.updateActivity();

--- a/backend/types/config.types.ts
+++ b/backend/types/config.types.ts
@@ -14,6 +14,7 @@ export interface PuppeteerConfig {
   keepAlive?: number; // Keep browser alive for this many milliseconds (default: 10 minutes)
   maxRetries?: number; // Maximum retry attempts for browser operations (default: 3)
   retryDelay?: number; // Delay between retry attempts in milliseconds (default: 2000)
+  executablePath?: string; // Override Puppeteer bundled Chrome (e.g. for ARM)
 }
 
 export interface CifraClubConfig {

--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import MetadataBadge from "./MetadataBadge";
 import type { ChordMetadataProps } from "./ChordMetadata.types";
-import { normalizeNamePart } from "@/utils/chord-sheet-path";
+import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArtist";
 
-const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet }) => {
+const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, path }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -22,8 +22,15 @@ const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet }) => {
 
   const handleArtistClick = () => {
     if (chordSheet.artist) {
-      const artistPath = `/${normalizeNamePart(chordSheet.artist)}`;
-      navigate(artistPath);
+      const artistSlug = path.split("/")[0];
+      sessionStorage.removeItem("chordium_search_query");
+      try {
+        sessionStorage.setItem(
+          ARTIST_DISPLAY_NAME_KEY,
+          JSON.stringify({ path: artistSlug, displayName: chordSheet.artist })
+        );
+      } catch {}
+      navigate(`/${artistSlug}`);
     }
   };
 

--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.types.ts
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.types.ts
@@ -7,4 +7,6 @@ import type { ChordSheet } from '@/types/chordSheet';
 export interface ChordMetadataProps {
   /** Chord sheet object containing all metadata */
   chordSheet: ChordSheet;
+  /** Path of the song (e.g. "ac-dc/back-in-black"), used to derive the artist slug */
+  path: string;
 }

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -106,7 +106,7 @@ const SongViewer = ({
         }
       />
       <div className="py-2 pl-1 sm:py-0 sm:px-1">
-        <ChordMetadata chordSheet={chordSheetToDisplay} />
+        <ChordMetadata chordSheet={chordSheetToDisplay} path={songObj.path} />
       </div>
       <ChordDisplay
         ref={chordDisplayRef}

--- a/frontend/src/search/hooks/useSearchReducer/handlers/useArtistSongsFetch.ts
+++ b/frontend/src/search/hooks/useSearchReducer/handlers/useArtistSongsFetch.ts
@@ -36,9 +36,7 @@ export const useArtistSongsFetch = ({
         if (import.meta.env.DEV) {
           console.error("[useArtistSongsFetch] ARTIST SONGS ERROR:", err);
         }
-        const errorMessage =
-          err instanceof Error ? err.message : "Failed to fetch artist songs";
-        dispatch({ type: "ARTIST_SONGS_ERROR", error: errorMessage });
+        dispatch({ type: "ARTIST_SONGS_ERROR", error: "Could not load songs for this artist. Please try again." });
       } finally {
         setArtistSongsFetching(false);
         isArtistSongsFetching.current = false;

--- a/frontend/src/storage/services/sample-chord-sheets/data-loader.ts
+++ b/frontend/src/storage/services/sample-chord-sheets/data-loader.ts
@@ -31,7 +31,7 @@ export const loadSampleMetadata = async (): Promise<Array<{ path: string; metada
         metadata: wonderwallMetadata.default as SongMetadata
       },
       {
-        path: 'eagles/hotel-california',
+        path: 'the-eagles/hotel-california',
         metadata: hotelCaliforniaMetadata.default as SongMetadata
       }
     ];
@@ -60,7 +60,7 @@ export const loadSampleContent = async (path: string): Promise<ChordSheet> => {
       case 'oasis/wonderwall':
         contentModule = await import('../../data/samples/chord-sheets/content/oasis-wonderwall.json');
         break;
-      case 'eagles/hotel-california':
+      case 'the-eagles/hotel-california':
         contentModule = await import('../../data/samples/chord-sheets/content/eagles-hotel_california.json');
         break;
       default:

--- a/frontend/src/storage/services/sample-chord-sheets/path-resolver.ts
+++ b/frontend/src/storage/services/sample-chord-sheets/path-resolver.ts
@@ -2,8 +2,8 @@
  * Path resolution service for sample chord sheets
  * 
  * Handles the mapping between different ID formats:
- * - URL-based paths (from generateChordSheetPath): "eagles_hotel-california"
- * - Database paths (slash format): "eagles/hotel-california"
+ * - URL-based paths (from generateChordSheetPath): "the-eagles_hotel-california"
+ * - Database paths (slash format): "the-eagles/hotel-california"
  */
 
 import { chordSheetPathToStoragePath } from '@/utils/chord-sheet-path';

--- a/frontend/src/storage/services/sample-chord-sheets/sample-paths.ts
+++ b/frontend/src/storage/services/sample-chord-sheets/sample-paths.ts
@@ -7,7 +7,7 @@
  */
 export const SAMPLE_CHORD_SHEET_PATHS = [
   'oasis/wonderwall',
-  'eagles/hotel-california'
+  'the-eagles/hotel-california'
 ] as const;
 
 /**

--- a/frontend/src/utils/__tests__/chord-sheet-path.test.ts
+++ b/frontend/src/utils/__tests__/chord-sheet-path.test.ts
@@ -130,7 +130,7 @@ describe('ChordSheet Path Generator', () => {
 
   describe('chordSheetPathToStoragePath', () => {
     it('should convert ID to path format', () => {
-      expect(chordSheetPathToStoragePath('eagles_hotel-california')).toBe('eagles/hotel-california');
+      expect(chordSheetPathToStoragePath('the-eagles_hotel-california')).toBe('the-eagles/hotel-california');
       expect(chordSheetPathToStoragePath('oasis_wonderwall')).toBe('oasis/wonderwall');
     });
 

--- a/frontend/src/utils/__tests__/navigation-utils.test.ts
+++ b/frontend/src/utils/__tests__/navigation-utils.test.ts
@@ -53,17 +53,17 @@ describe('NavigationUtils', () => {
       
       const path = navigationUtils.generateNavigationPath(data, false);
       
-      expect(path).toBe('/eagles/hotel-california');
+      expect(path).toBe('/the-eagles/hotel-california');
     });
 
     it('should detect My Chord Sheets context from path', () => {
-      const isMyChordSheets = navigationUtils.isMyChordSheetsContext('/my-chord-sheets/eagles/hotel-california');
+      const isMyChordSheets = navigationUtils.isMyChordSheetsContext('/my-chord-sheets/the-eagles/hotel-california');
       
       expect(isMyChordSheets).toBe(true);
     });
 
     it('should detect search context from path', () => {
-      const isMyChordSheets = navigationUtils.isMyChordSheetsContext('/eagles/hotel-california');
+      const isMyChordSheets = navigationUtils.isMyChordSheetsContext('/the-eagles/hotel-california');
       
       expect(isMyChordSheets).toBe(false);
     });

--- a/frontend/src/utils/route-context-detector.test.ts
+++ b/frontend/src/utils/route-context-detector.test.ts
@@ -15,7 +15,7 @@ describe('route-context-detector', () => {
   describe('isMyChordSheetsRoute', () => {
     it('should return true for My Chord Sheets routes', () => {
       // Arrange
-      window.location.pathname = '/my-chord-sheets/eagles/hotel-california';
+      window.location.pathname = '/my-chord-sheets/the-eagles/hotel-california';
 
       // Act
       const result = isMyChordSheetsRoute();
@@ -37,7 +37,7 @@ describe('route-context-detector', () => {
 
     it('should return false for search result routes', () => {
       // Arrange
-      window.location.pathname = '/eagles/hotel-california';
+      window.location.pathname = '/the-eagles/hotel-california';
 
       // Act
       const result = isMyChordSheetsRoute();
@@ -72,7 +72,7 @@ describe('route-context-detector', () => {
   describe('getRouteContext', () => {
     it('should return "my-chord-sheets" for My Chord Sheets routes', () => {
       // Arrange
-      window.location.pathname = '/my-chord-sheets/eagles/hotel-california';
+      window.location.pathname = '/my-chord-sheets/the-eagles/hotel-california';
 
       // Act
       const result = getRouteContext();
@@ -83,7 +83,7 @@ describe('route-context-detector', () => {
 
     it('should return "search" for search result routes', () => {
       // Arrange
-      window.location.pathname = '/eagles/hotel-california';
+      window.location.pathname = '/the-eagles/hotel-california';
 
       // Act
       const result = getRouteContext();


### PR DESCRIPTION
- Artist badge now navigates using the path slug (e.g. `ac-dc`) instead of normalizing the display name, fixing broken slugs like AC/DC
- Stores `displayName` in sessionStorage on badge click so the artist search header shows the correct name instead of the `fromSlug` fallback
- Clears stale search state before navigating to the artist page
- Artist fetch errors show a user-friendly message instead of raw 502 JSON
- Corrected Eagles sample chord sheet path to `the-eagles/hotel-california` to match CifraClub actual slug
- Added `PUPPETEER_EXECUTABLE_PATH` env var support for running Puppeteer on non-x86 environments (e.g. ARM64)
