### PR TITLE
fix: recover from stale chunk hashes after Vercel redeploy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider, Navigate } from "react-router-dom";
-import { lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense, useEffect, ComponentType } from 'react';
 import RootLayout from "@/components/layouts/RootLayout";
 import { GlobalErrorBoundary, RouteErrorBoundary, AsyncErrorBoundary } from "@/components/ErrorBoundaryWrappers";
 import { createQueryClientWithErrorHandling } from "@/utils/query-error-handling";
@@ -11,9 +11,28 @@ import OfflineRouteHandler from "@/components/OfflineRouteHandler";
 import SmallScreenWarning from "@/components/SmallScreenWarning";
 import { useServiceWorkerUpdate } from "@/hooks/useServiceWorkerUpdate";
 
+// Reload once on chunk load failures (stale cache after Vercel redeploy)
+const lazyWithChunkRetry = <T extends ComponentType<unknown>>(factory: () => Promise<{ default: T }>) =>
+  lazy(() =>
+    factory().catch((err: Error) => {
+      const isChunkError =
+        err.message.includes('Failed to fetch dynamically imported module') ||
+        err.message.includes('Importing a module script failed') ||
+        err.name === 'ChunkLoadError';
+      if (isChunkError) {
+        const key = 'chordium_chunk_reload_attempted';
+        if (!sessionStorage.getItem(key)) {
+          sessionStorage.setItem(key, '1');
+          window.location.reload();
+        }
+      }
+      throw err;
+    })
+  );
+
 // Lazy load pages instead of direct imports
-const Home = lazy(() => import("./pages/Home"));
-const ChordViewer = lazy(() => import("./pages/chord-viewer"));
+const Home = lazyWithChunkRetry(() => import("./pages/Home"));
+const ChordViewer = lazyWithChunkRetry(() => import("./pages/chord-viewer"));
 // Temporarily removed SmartRouteHandler to fix rendering issues
 // const SmartRouteHandler = lazy(() => import("./components/SmartRouteHandler"));
 
@@ -156,3 +175,4 @@ const App = () => (
 
 
 export default App;
+

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -44,9 +44,28 @@ class ErrorBoundary extends Component<Props, State> {
     };
   }
 
+  private readonly isChunkLoadError = (error: Error): boolean => {
+    return (
+      error.message.includes('Failed to fetch dynamically imported module') ||
+      error.message.includes('Importing a module script failed') ||
+      error.name === 'ChunkLoadError'
+    );
+  };
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
-    
+
+    if (this.isChunkLoadError(error)) {
+      const reloadKey = 'chordium_chunk_reload_attempted';
+      if (!sessionStorage.getItem(reloadKey)) {
+        sessionStorage.setItem(reloadKey, '1');
+        window.location.reload();
+        return;
+      }
+      // Already tried reloading once — clear the flag so future navigations can retry
+      sessionStorage.removeItem(reloadKey);
+    }
+
     this.setState({
       error,
       errorInfo

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    }
+  ]
+}


### PR DESCRIPTION
- After a redeploy, Vite changes chunk hashes — browsers with cached HTML try to load old filenames that no longer exist, causing a \"Failed to fetch dynamically imported module\" error
- Added `lazyWithChunkRetry` in `App.tsx` — wraps `lazy()` imports to detect chunk load errors and trigger a hard reload once (guarded by `sessionStorage` to prevent loops)
- Added the same detection in `ErrorBoundary` as a fallback in case the error reaches React before the promise rejection is handled
- Added `vercel.json` with `no-cache` on HTML (root cause fix — browser always fetches fresh HTML with correct chunk hashes) and `immutable` on `/assets/*` (hashed chunks can be cached forever)