### PR TITLE
feat: add microphone-based chromatic guitar tuner

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const lazyWithChunkRetry = <T extends ComponentType<unknown>>(factory: () => Pro
 // Lazy load pages instead of direct imports
 const Home = lazyWithChunkRetry(() => import("./pages/Home"));
 const ChordViewer = lazyWithChunkRetry(() => import("./pages/chord-viewer"));
+const TunerPage = lazyWithChunkRetry(() => import("./features/tuner/TunerPage"));
 // Temporarily removed SmartRouteHandler to fix rendering issues
 // const SmartRouteHandler = lazy(() => import("./components/SmartRouteHandler"));
 
@@ -98,6 +99,18 @@ const router = createBrowserRouter([
             <AsyncErrorBoundary>
               <Suspense fallback={<Loading />}>
                 <Home />
+              </Suspense>
+            </AsyncErrorBoundary>
+          </RouteErrorBoundary>
+        )
+      },
+      {
+        path: "tuner",
+        element: (
+          <RouteErrorBoundary>
+            <AsyncErrorBoundary>
+              <Suspense fallback={<Loading />}>
+                <TunerPage />
               </Suspense>
             </AsyncErrorBoundary>
           </RouteErrorBoundary>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,5 @@
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
+import { Music2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ShareSession } from "@/features/jam-session";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -31,6 +32,15 @@ const Header = () => {
           <ShareSession />
           <OfflineIndicator />
           <LanguageSwitcher />
+          <NavLink
+            to="/tuner"
+            className={({ isActive }) =>
+              `p-1.5 rounded-md transition-colors hover:bg-accent ${isActive ? "text-primary" : "text-muted-foreground hover:text-foreground"}`
+            }
+            aria-label="Guitar Tuner"
+          >
+            <Music2 className="w-5 h-5" />
+          </NavLink>
           <ThemeToggle />
         </div>
       </div>

--- a/frontend/src/features/tuner/TunerNeedle.tsx
+++ b/frontend/src/features/tuner/TunerNeedle.tsx
@@ -1,0 +1,100 @@
+interface TunerNeedleProps {
+  cents: number | null; // -50 to +50
+  isInTune: boolean;
+}
+
+const TunerNeedle = ({ cents, isInTune }: TunerNeedleProps) => {
+  const rotation = cents !== null ? (cents / 50) * 75 : 0; // max ±75deg
+  const active = cents !== null;
+
+  return (
+    <div className="relative flex flex-col items-center select-none">
+      {/* Arc background */}
+      <svg viewBox="0 0 240 130" className="w-64 h-36" aria-hidden>
+        {/* Track arc */}
+        <path
+          d="M 20 120 A 100 100 0 0 1 220 120"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          className="text-muted-foreground/30"
+        />
+        {/* Center in-tune zone */}
+        <path
+          d="M 113 23 A 97 97 0 0 1 127 23"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="6"
+          strokeLinecap="round"
+          className={isInTune && active ? "text-green-500" : "text-muted-foreground/20"}
+        />
+        {/* Tick marks */}
+        {[-50, -25, 0, 25, 50].map((val) => {
+          const angleDeg = (val / 50) * 75 - 90;
+          const rad = (angleDeg * Math.PI) / 180;
+          const r1 = 94, r2 = 104, cx = 120, cy = 120;
+          return (
+            <line
+              key={val}
+              x1={cx + r1 * Math.cos(rad)}
+              y1={cy + r1 * Math.sin(rad)}
+              x2={cx + r2 * Math.cos(rad)}
+              y2={cy + r2 * Math.sin(rad)}
+              stroke="currentColor"
+              strokeWidth={val === 0 ? 2 : 1}
+              className="text-muted-foreground/50"
+            />
+          );
+        })}
+        {/* Needle */}
+        <g
+          transform={`rotate(${rotation}, 120, 120)`}
+          style={{ transition: active ? "transform 0.08s ease-out" : "none" }}
+        >
+          <line
+            x1="120" y1="120"
+            x2="120" y2="28"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className={
+              !active
+                ? "text-muted-foreground/40"
+                : isInTune
+                ? "text-green-500"
+                : "text-primary"
+            }
+          />
+        </g>
+        {/* Pivot dot */}
+        <circle
+          cx="120" cy="120" r="5"
+          className={
+            !active
+              ? "fill-muted-foreground/40"
+              : isInTune
+              ? "fill-green-500"
+              : "fill-primary"
+          }
+        />
+        {/* Cent labels */}
+        {[
+          { val: -50, x: 14, y: 118 },
+          { val: 50, x: 222, y: 118 },
+        ].map(({ val, x, y }) => (
+          <text
+            key={val}
+            x={x} y={y}
+            textAnchor="middle"
+            fontSize="10"
+            className="fill-muted-foreground"
+          >
+            {val > 0 ? `+${val}` : val}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+export default TunerNeedle;

--- a/frontend/src/features/tuner/TunerPage.tsx
+++ b/frontend/src/features/tuner/TunerPage.tsx
@@ -1,0 +1,158 @@
+import { usePitchDetector } from "@/hooks/usePitchDetector";
+import TunerNeedle from "./TunerNeedle";
+import { Button } from "@/components/ui/button";
+import { Mic, MicOff, Music } from "lucide-react";
+
+const NOTE_STANDARD: Record<string, string> = {
+  E: "E (1st/6th)",
+  B: "B (2nd)",
+  G: "G (3rd)",
+  D: "D (4th)",
+  A: "A (5th)",
+};
+
+const TunerPage = () => {
+  const { status, pitch, errorMessage, start, stop } = usePitchDetector();
+  const isListening = status === "listening";
+  const hasNote = pitch.note !== null && pitch.frequency !== null;
+
+  const centsLabel =
+    pitch.cents === null
+      ? ""
+      : pitch.cents === 0
+      ? "In tune"
+      : pitch.cents > 0
+      ? `+${pitch.cents}¢ sharp`
+      : `${pitch.cents}¢ flat`;
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] px-4 py-8">
+      <div className="w-full max-w-sm space-y-6">
+        {/* Title */}
+        <div className="text-center space-y-1">
+          <div className="flex items-center justify-center gap-2">
+            <Music className="w-5 h-5 text-primary" />
+            <h2 className="text-xl font-semibold">Chromatic Tuner</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Play a string and tune to the nearest note
+          </p>
+        </div>
+
+        {/* Needle display */}
+        <div className="flex flex-col items-center gap-2">
+          <TunerNeedle cents={pitch.cents} isInTune={!!pitch.isInTune} />
+
+          {/* Note display */}
+          <div
+            className={`text-center transition-all duration-150 ${
+              hasNote ? "opacity-100" : "opacity-30"
+            }`}
+          >
+            <div
+              className={`text-7xl font-bold leading-none tracking-tight ${
+                pitch.isInTune && hasNote
+                  ? "text-green-500"
+                  : "text-foreground"
+              }`}
+            >
+              {hasNote ? pitch.note : "—"}
+            </div>
+            <div className="text-sm text-muted-foreground mt-1 h-5">
+              {hasNote ? (
+                <>
+                  <span>{pitch.frequency} Hz</span>
+                  {pitch.octave !== null && (
+                    <span className="ml-2 opacity-60">oct {pitch.octave}</span>
+                  )}
+                  {NOTE_STANDARD[pitch.note!] && (
+                    <span className="ml-2 opacity-60">
+                      · {NOTE_STANDARD[pitch.note!]}
+                    </span>
+                  )}
+                </>
+              ) : null}
+            </div>
+            <div
+              className={`text-sm font-medium mt-1 h-5 ${
+                pitch.isInTune && hasNote
+                  ? "text-green-500"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {hasNote ? centsLabel : ""}
+            </div>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="flex flex-col items-center gap-3">
+          {status === "error" && errorMessage && (
+            <p className="text-sm text-destructive text-center">{errorMessage}</p>
+          )}
+
+          <Button
+            size="lg"
+            variant={isListening ? "outline" : "default"}
+            className="w-40 gap-2"
+            onClick={isListening ? stop : start}
+          >
+            {isListening ? (
+              <>
+                <MicOff className="w-4 h-4" />
+                Stop
+              </>
+            ) : (
+              <>
+                <Mic className="w-4 h-4" />
+                Start Tuner
+              </>
+            )}
+          </Button>
+
+          {isListening && (
+            <p className="text-xs text-muted-foreground animate-pulse">
+              Listening…
+            </p>
+          )}
+        </div>
+
+        {/* Standard tuning reference */}
+        <div className="border rounded-lg p-4 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Standard Tuning
+          </p>
+          <div className="grid grid-cols-6 gap-1 text-center">
+            {[
+              { string: "6", note: "E2" },
+              { string: "5", note: "A2" },
+              { string: "4", note: "D3" },
+              { string: "3", note: "G3" },
+              { string: "2", note: "B3" },
+              { string: "1", note: "E4" },
+            ].map(({ string, note }) => {
+              const baseNote = note.replace(/\d/, "");
+              const highlighted =
+                hasNote && pitch.isInTune && pitch.note === baseNote;
+              return (
+                <div
+                  key={string}
+                  className={`rounded p-1.5 text-xs transition-colors ${
+                    highlighted
+                      ? "bg-green-500/20 text-green-600 dark:text-green-400 font-semibold"
+                      : "bg-muted/50 text-muted-foreground"
+                  }`}
+                >
+                  <div className="font-medium">{note}</div>
+                  <div className="opacity-60 text-[10px]">str {string}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TunerPage;

--- a/frontend/src/hooks/usePitchDetector.ts
+++ b/frontend/src/hooks/usePitchDetector.ts
@@ -1,0 +1,150 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export type TunerStatus = "idle" | "listening" | "error";
+
+export interface PitchResult {
+  frequency: number | null;
+  note: string | null;
+  octave: number | null;
+  cents: number | null; // -50 to +50, 0 = in tune
+  isInTune: boolean;
+}
+
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+const A4_FREQ = 440;
+const A4_MIDI = 69;
+const IN_TUNE_THRESHOLD = 5; // cents
+
+function frequencyToNoteInfo(freq: number): Omit<PitchResult, "frequency"> {
+  const midiNote = 12 * Math.log2(freq / A4_FREQ) + A4_MIDI;
+  const roundedMidi = Math.round(midiNote);
+  const cents = Math.round((midiNote - roundedMidi) * 100);
+  const noteIndex = ((roundedMidi % 12) + 12) % 12;
+  const octave = Math.floor(roundedMidi / 12) - 1;
+  return {
+    note: NOTE_NAMES[noteIndex],
+    octave,
+    cents,
+    isInTune: Math.abs(cents) <= IN_TUNE_THRESHOLD,
+  };
+}
+
+// Autocorrelation-based pitch detection
+function detectPitch(buffer: Float32Array, sampleRate: number): number | null {
+  const SIZE = buffer.length;
+  const MAX_SAMPLES = Math.floor(SIZE / 2);
+  const MIN_FREQ = 60;
+  const MAX_FREQ = 1400;
+
+  let rms = 0;
+  for (let i = 0; i < SIZE; i++) rms += buffer[i] * buffer[i];
+  rms = Math.sqrt(rms / SIZE);
+  if (rms < 0.01) return null; // too quiet
+
+  const correlations = new Float32Array(MAX_SAMPLES);
+  for (let lag = 0; lag < MAX_SAMPLES; lag++) {
+    let sum = 0;
+    for (let i = 0; i < MAX_SAMPLES; i++) {
+      sum += buffer[i] * buffer[i + lag];
+    }
+    correlations[lag] = sum;
+  }
+
+  const minLag = Math.floor(sampleRate / MAX_FREQ);
+  const maxLag = Math.floor(sampleRate / MIN_FREQ);
+
+  let bestLag = -1;
+  let bestVal = -Infinity;
+  let i = minLag;
+  while (i < maxLag) {
+    if (correlations[i] > bestVal) {
+      bestVal = correlations[i];
+      bestLag = i;
+    }
+    i++;
+  }
+
+  if (bestLag === -1 || bestVal < correlations[0] * 0.5) return null;
+
+  // Parabolic interpolation for sub-sample accuracy
+  const y1 = correlations[bestLag - 1] ?? 0;
+  const y2 = correlations[bestLag];
+  const y3 = correlations[bestLag + 1] ?? 0;
+  const denom = 2 * (2 * y2 - y1 - y3);
+  const refinedLag = denom === 0 ? bestLag : bestLag + (y3 - y1) / denom;
+
+  return sampleRate / refinedLag;
+}
+
+export function usePitchDetector() {
+  const [status, setStatus] = useState<TunerStatus>("idle");
+  const [pitch, setPitch] = useState<PitchResult>({
+    frequency: null,
+    note: null,
+    octave: null,
+    cents: null,
+    isInTune: false,
+  });
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const bufferRef = useRef<Float32Array | null>(null);
+
+  const stop = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = null;
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    audioContextRef.current?.close();
+    audioContextRef.current = null;
+    analyserRef.current = null;
+    setStatus("idle");
+    setPitch({ frequency: null, note: null, octave: null, cents: null, isInTune: false });
+  }, []);
+
+  const start = useCallback(async () => {
+    try {
+      setErrorMessage(null);
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const ctx = new AudioContext();
+      audioContextRef.current = ctx;
+
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 2048;
+      analyserRef.current = analyser;
+      bufferRef.current = new Float32Array(analyser.fftSize);
+
+      const source = ctx.createMediaStreamSource(stream);
+      source.connect(analyser);
+
+      setStatus("listening");
+
+      const tick = () => {
+        if (!analyserRef.current || !bufferRef.current) return;
+        analyserRef.current.getFloatTimeDomainData(bufferRef.current);
+        const freq = detectPitch(bufferRef.current, ctx.sampleRate);
+        if (freq !== null) {
+          const info = frequencyToNoteInfo(freq);
+          setPitch({ frequency: Math.round(freq * 10) / 10, ...info });
+        } else {
+          setPitch((prev) => ({ ...prev, frequency: null }));
+        }
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Microphone access denied";
+      setErrorMessage(msg);
+      setStatus("error");
+    }
+  }, []);
+
+  useEffect(() => () => stop(), [stop]);
+
+  return { status, pitch, errorMessage, start, stop };
+}


### PR DESCRIPTION
## Summary

Adds a chromatic tuner accessible from the header and at `/tuner`.

## Features

- **Microphone-based pitch detection** using Web Audio API autocorrelation with parabolic interpolation for accuracy
- **Animated needle display** showing cents deviation (±50¢), turns green when within ±5¢
- **Note + frequency readout** with octave and standard string hint
- **Standard tuning reference grid** (E2–A2–D3–G3–B3–E4) that highlights the matching string when in tune
- **Header nav icon** that highlights when the tuner route is active
- Lazy-loaded — zero impact on initial bundle

## How to test

1. Go to `/tuner`
2. Click **Start Tuner** and allow microphone access
3. Play a guitar string — the needle, note, and grid should respond in real time