### PR TITLE
feat: results sorting for search and My Songs

### DIFF
--- a/frontend/src/components/chord-sheet-list.tsx
+++ b/frontend/src/components/chord-sheet-list.tsx
@@ -48,9 +48,9 @@ const ChordSheetList = ({
     <div>
       {chordSheets.length > 0 ? (
         <>
-          <div className="flex justify-end mb-3">
+          <div className="flex justify-end mb-4 sm:mb-6">
             <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
-              <SelectTrigger className="w-40 [&>span]:text-left">
+              <SelectTrigger className="w-40 bg-card [&>span]:text-left">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/components/chord-sheet-list.tsx
+++ b/frontend/src/components/chord-sheet-list.tsx
@@ -1,9 +1,31 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { ChordSheetListProps } from "./chord-sheet-list.types";
+import type { ChordSheetListProps, SortOption } from "./chord-sheet-list.types";
 import ChordSheetCard from "@/chord-sheet/components/ChordSheetCard";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useRestoreScrollPosition, usePersistScrollPosition } from "@/hooks/useScrollPosition";
+import type { ChordSheetListItem } from "@/storage/stores/chord-sheets/operations/get-all-saved";
+
+function sortChordSheets(items: ChordSheetListItem[], sort: SortOption): ChordSheetListItem[] {
+  const arr = [...items];
+  switch (sort) {
+    case "recent":
+      return arr.sort((a, b) => (b.storage.lastAccessed ?? 0) - (a.storage.lastAccessed ?? 0));
+    case "az":
+      return arr.sort((a, b) => a.title.localeCompare(b.title));
+    case "za":
+      return arr.sort((a, b) => b.title.localeCompare(a.title));
+    case "most-played":
+      return arr.sort((a, b) => (b.storage.accessCount ?? 0) - (a.storage.accessCount ?? 0));
+  }
+}
 
 const ChordSheetList = ({
   chordSheets,
@@ -11,27 +33,47 @@ const ChordSheetList = ({
   onDeleteChordSheet,
   onUploadClick,
   tabState,
-  setTabState
+  setTabState,
 }: ChordSheetListProps) => {
   const { t } = useTranslation();
   const listRef = useRef<HTMLDivElement>(null);
+  const [sort, setSort] = useState<SortOption>("recent");
 
   useRestoreScrollPosition(listRef, tabState?.scroll);
   usePersistScrollPosition(listRef, setTabState ? (scroll) => setTabState({ scroll }) : undefined);
 
+  const sorted = sortChordSheets(chordSheets, sort);
+
   return (
-    <div ref={listRef} className="max-h-[60vh] overflow-y-auto">
+    <div>
       {chordSheets.length > 0 ? (
-        <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
-          {[...chordSheets].reverse().map((storedChordSheet, index) => (
-            <ChordSheetCard
-              key={`${storedChordSheet.path}-${index}`}
-              chordSheet={storedChordSheet}
-              onView={onChordSheetSelect}
-              onDelete={() => onDeleteChordSheet(storedChordSheet.path)}
-            />
-          ))}
-        </div>
+        <>
+          <div className="flex justify-end mb-3">
+            <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
+              <SelectTrigger className="w-40 [&>span]:text-left">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="recent">{t("sort.recent")}</SelectItem>
+                <SelectItem value="most-played">{t("sort.mostPlayed")}</SelectItem>
+                <SelectItem value="az">{t("sort.az")}</SelectItem>
+                <SelectItem value="za">{t("sort.za")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div ref={listRef} className="max-h-[60vh] overflow-y-auto">
+            <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+              {sorted.map((storedChordSheet, index) => (
+                <ChordSheetCard
+                  key={`${storedChordSheet.path}-${index}`}
+                  chordSheet={storedChordSheet}
+                  onView={onChordSheetSelect}
+                  onDelete={() => onDeleteChordSheet(storedChordSheet.path)}
+                />
+              ))}
+            </div>
+          </div>
+        </>
       ) : (
         <div className="text-center py-8">
           <p className="text-muted-foreground mb-3">{t("chordSheetList.empty")}</p>

--- a/frontend/src/components/chord-sheet-list.types.ts
+++ b/frontend/src/components/chord-sheet-list.types.ts
@@ -1,8 +1,10 @@
-import type { StoredSongMetadata } from "@/storage/types";
+import type { ChordSheetListItem } from "@/storage/stores/chord-sheets/operations/get-all-saved";
+
+export type SortOption = "recent" | "az" | "za" | "most-played";
 
 export interface ChordSheetListProps {
-  chordSheets: StoredSongMetadata[];
-  onChordSheetSelect: (metadata: StoredSongMetadata) => void;
+  chordSheets: ChordSheetListItem[];
+  onChordSheetSelect: (metadata: ChordSheetListItem) => void;
   onDeleteChordSheet: (chordSheetPath: string) => void;
   onUploadClick: () => void;
   tabState?: { scroll: number };

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -164,5 +164,12 @@
     "outro": "Outro",
     "solo": "Solo",
     "interlude": "Interlude"
+  },
+  "sort": {
+    "default": "Relevance",
+    "az": "A → Z",
+    "za": "Z → A",
+    "recent": "Recent",
+    "mostPlayed": "Most played"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -164,5 +164,12 @@
     "outro": "Outro",
     "solo": "Solo",
     "interlude": "Interludio"
+  },
+  "sort": {
+    "default": "Relevancia",
+    "az": "A → Z",
+    "za": "Z → A",
+    "recent": "Recientes",
+    "mostPlayed": "Más escuchado"
   }
 }

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -164,5 +164,12 @@
     "outro": "Outro",
     "solo": "Solo",
     "interlude": "Interlúdio"
+  },
+  "sort": {
+    "default": "Relevância",
+    "az": "A → Z",
+    "za": "Z → A",
+    "recent": "Recentes",
+    "mostPlayed": "Mais tocados"
   }
 }

--- a/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
+++ b/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
@@ -1,9 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import ResultsList from "@/components/ui/ResultsList";
 import SearchResultsSection from "../SearchResultsSection/SearchResultsSection";
-import type { SearchResultsLayoutProps } from "./SearchResultsLayout.types";
+import type { SearchResult, SearchResultsLayoutProps } from "./SearchResultsLayout.types";
 import { ResultCard } from "../../ResultCard";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type SortOption = "default" | "az" | "za";
+
+function sortResults(items: SearchResult[], sort: SortOption): SearchResult[] {
+  if (sort === "default") return items;
+  const arr = [...items];
+  const label = (r: SearchResult) => r.type === "song" ? r.title : r.displayName;
+  return arr.sort((a, b) =>
+    sort === "az"
+      ? label(a).localeCompare(label(b))
+      : label(b).localeCompare(label(a))
+  );
+}
 
 const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
   results = [],
@@ -14,6 +34,7 @@ const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
   activeArtist,
 }) => {
   const { t } = useTranslation();
+  const [sort, setSort] = useState<SortOption>("default");
 
   if (results.length === 0) {
     return (
@@ -39,11 +60,25 @@ const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
     }
   };
 
+  const sorted = sortResults(results, sort);
+
   return (
     <div className="flex flex-col gap-8 w-full">
       <SearchResultsSection title={getSectionTitle()} count={results.length}>
+        <div className="flex justify-end mb-2">
+          <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
+            <SelectTrigger className="w-36 [&>span]:text-left">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">{t("sort.default")}</SelectItem>
+              <SelectItem value="az">{t("sort.az")}</SelectItem>
+              <SelectItem value="za">{t("sort.za")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <ResultsList
-          items={results}
+          items={sorted}
           renderItem={({ item }) => (
             <ResultCard key={item.path} result={item} onClick={onResultClick} />
           )}

--- a/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
+++ b/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
@@ -67,7 +67,7 @@ const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
       <SearchResultsSection title={getSectionTitle()} count={results.length}>
         <div className="flex justify-end mb-2">
           <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
-            <SelectTrigger className="w-36 [&>span]:text-left">
+            <SelectTrigger className="w-36 bg-card [&>span]:text-left">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
+++ b/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
@@ -112,8 +112,10 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
           songCount: null,
         });
         
-        // IMPORTANT: Restore the original search query from session storage
-        // This ensures the input fields show the original search query
+        // Restore the original search query from session storage if present.
+        // If absent (e.g. navigating here from a chord sheet artist link), fall
+        // back to the artist display name so the input field is not left empty.
+        let restoredFromSession = false;
         try {
           const storedQuery = sessionStorage.getItem('chordium_search_query');
           if (storedQuery) {
@@ -128,10 +130,16 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
               setOriginalSearchArtist(artist || '');
               setOriginalSearchSong(song || '');
               setHasSearched(true);
+              restoredFromSession = true;
             }
           }
         } catch (error) {
           console.warn('Failed to restore search query from session storage:', error);
+        }
+
+        if (!restoredFromSession) {
+          setArtistInput(artistName);
+          setPrevArtistInput(artistName);
         }
         
         // Don't set submittedArtist here - preserve the original search query

--- a/frontend/src/storage/stores/chord-sheets/operations/get-all-saved.ts
+++ b/frontend/src/storage/stores/chord-sheets/operations/get-all-saved.ts
@@ -2,33 +2,11 @@ import type { StoredSongMetadata } from "../../../types/stored-song-metadata";
 import { executeReadTransaction } from "../../../core/transactions";
 import { STORES } from "../../../core/config/stores";
 
-/**
- * Metadata type for list view - only fields actually used by UI components
- */
-export type ChordSheetListItem = {
-  title: string;
-  artist: string;
-  path: string;
-};
+export type ChordSheetListItem = StoredSongMetadata;
 
-/**
- * @returns Chord sheets marked as saved by the user
- * @throws {DatabaseOperationError} When storage access fails
- */
-export default async function getAllSavedChordSheets(): Promise<
-  ChordSheetListItem[]
-> {
-  // Read only the fields we actually need for the list view
-  const savedMetadata = await executeReadTransaction<StoredSongMetadata[]>(STORES.SONGS_METADATA, (store) =>
+export default async function getAllSavedChordSheets(): Promise<ChordSheetListItem[]> {
+  const allRecords = await executeReadTransaction<StoredSongMetadata[]>(STORES.SONGS_METADATA, (store) =>
     store.getAll()
-  ).then((allRecords) =>
-    allRecords.filter((record) => record.storage?.saved === true)
   );
-
-  // Return minimal objects - only title, artist, path (what UI actually uses)
-  return savedMetadata.map((metadata): ChordSheetListItem => ({
-    title: metadata.title,
-    artist: metadata.artist,
-    path: metadata.path,
-  }));
+  return allRecords.filter((record) => record.storage?.saved === true);
 }


### PR DESCRIPTION
Closes #41

Adds sort controls to the search results and My Songs (Songbook) tab.

**My Songs** — 4 options: Recent, Most Played, A → Z, Z → A. Uses `lastAccessed` and `accessCount` from stored metadata.

**Search results** — 3 options: Relevance (default/API order), A → Z, Z → A.

Translated across EN, ES, and PT-BR.