### PR TITLE
feat: prompt users to reload when a new app version is available

### DIFF
--- a/frontend/src/hooks/useServiceWorkerUpdate.tsx
+++ b/frontend/src/hooks/useServiceWorkerUpdate.tsx
@@ -1,41 +1,30 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import { useRegisterSW } from "virtual:pwa-register/react";
 import { toast } from "./use-toast";
 import { ToastAction } from "@/components/ui/toast";
 import i18n from "@/i18n/config";
 
 export function useServiceWorkerUpdate() {
-  const waitingWorkerRef = useRef<ServiceWorker | null>(null);
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW();
 
   useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      const showUpdateToast = (waiting: ServiceWorker) => {
-        waitingWorkerRef.current = waiting;
-        toast({
-          title: i18n.t("notifications:updateAvailable"),
-          description: i18n.t("notifications:updateAvailableDesc"),
-          action: (
-            <ToastAction
-              altText={i18n.t("notifications:updateReloadAltText")}
-              onClick={() => {
-                waiting.postMessage({ type: "SKIP_WAITING" });
-                window.location.reload();
-              }}
-            >
-              {i18n.t("notifications:updateReload")}
-            </ToastAction>
-          ),
-        });
-      };
+    if (!needRefresh) return;
 
-      window.addEventListener("swUpdated", (event: CustomEvent) => {
-        const waiting = event.detail?.waiting as ServiceWorker | undefined;
-        if (waiting) showUpdateToast(waiting);
-      });
-
-      window.addEventListener("workbox-waiting", (event: CustomEvent) => {
-        const waiting = event.detail?.waiting as ServiceWorker | undefined;
-        if (waiting) showUpdateToast(waiting);
-      });
-    }
-  }, []);
+    toast({
+      title: i18n.t("notifications:updateAvailable"),
+      description: i18n.t("notifications:updateAvailableDesc"),
+      duration: Infinity,
+      action: (
+        <ToastAction
+          altText={i18n.t("notifications:updateReloadAltText")}
+          onClick={() => updateServiceWorker(true)}
+        >
+          {i18n.t("notifications:updateReload")}
+        </ToastAction>
+      ),
+    });
+  }, [needRefresh, updateServiceWorker]);
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -58,7 +58,7 @@ export default defineConfig(({ mode }) => {
       //   ext: '.gz',
       // }),
       VitePWA({
-        registerType: 'autoUpdate',
+        registerType: 'prompt',
         manifest: {
           name: 'Chordium',
           short_name: 'Chordium',
@@ -132,7 +132,7 @@ export default defineConfig(({ mode }) => {
         workbox: {
           cleanupOutdatedCaches: true,
           clientsClaim: true,
-          skipWaiting: true,
+
           globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff2,json}'],
           // Re-enable navigateFallback but with better caching
           navigateFallback: '/index.html',
@@ -143,7 +143,7 @@ export default defineConfig(({ mode }) => {
               urlPattern: /manifest\.json$/,
               handler: 'CacheFirst',
               options: {
-                cacheName: 'chordium-v1-manifest',
+                cacheName: 'chordium-v2-manifest',
                 expiration: {
                   maxEntries: 1,
                   maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
@@ -158,7 +158,7 @@ export default defineConfig(({ mode }) => {
               urlPattern: /\.(?:js|css|html)$/,
               handler: 'CacheFirst',
               options: {
-                cacheName: 'chordium-v1-app-assets',
+                cacheName: 'chordium-v2-app-assets',
                 expiration: {
                   maxEntries: 100,
                   maxAgeSeconds: 60 * 60 * 24 * 7, // 7 days
@@ -172,7 +172,7 @@ export default defineConfig(({ mode }) => {
               urlPattern: /\/api\//,
               handler: 'NetworkFirst',
               options: {
-                cacheName: 'chordium-v1-api-responses',
+                cacheName: 'chordium-v2-api-responses',
                 networkTimeoutSeconds: 10,
                 expiration: {
                   maxEntries: 50,
@@ -187,7 +187,7 @@ export default defineConfig(({ mode }) => {
               urlPattern: /\.(?:png|jpg|jpeg|svg|webp|gif|ico)$/,
               handler: 'CacheFirst',
               options: {
-                cacheName: 'chordium-v1-images',
+                cacheName: 'chordium-v2-images',
                 expiration: {
                   maxEntries: 60,
                   maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days


### PR DESCRIPTION
When a new version of the app is deployed, users now see a toast notification prompting them to reload. Previously, updates were applied silently in the background but the running page session would stay on stale code until the user happened to reload on their own.

The toast stays visible until the user acts on it - it won't auto-dismiss.