### PR TITLE
feat: edit chord sheets and song metadata

### DIFF
--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -261,14 +261,20 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     }
   }
 
-  const guitarTuning: ["E", "A", "D", "G", "B", "E"] = [
-    "E",
-    "A",
-    "D",
-    "G",
-    "B",
-    "E",
-  ]; // Standard tuning default
+  // Extract tuning from span#cifra_afi a element (CifraClub specific).
+  // The element is only present when the tuning is non-standard; when it is
+  // absent we fall back to standard tuning.
+  let guitarTuning: GuitarTuning = ["E", "A", "D", "G", "B", "E"];
+  const tuningElement = document.querySelector("span#cifra_afi a");
+  if (tuningElement) {
+    const notes = (tuningElement.textContent || "")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (notes.length === 6) {
+      guitarTuning = notes as unknown as GuitarTuning;
+    }
+  }
 
   return {
     songChords,
@@ -403,14 +409,20 @@ export function extractSongMetadata(): SongMetadata {
     }
   }
 
-  const guitarTuning: GuitarTuning = [
-    "E",
-    "A",
-    "D",
-    "G",
-    "B",
-    "E",
-  ]; // Standard tuning default
+  // Extract tuning from span#cifra_afi a element (CifraClub specific).
+  // The element is only present when the tuning is non-standard; when it is
+  // absent we fall back to standard tuning.
+  let guitarTuning: GuitarTuning = ["E", "A", "D", "G", "B", "E"];
+  const tuningElement = document.querySelector("span#cifra_afi a");
+  if (tuningElement) {
+    const notes = (tuningElement.textContent || "")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (notes.length === 6) {
+      guitarTuning = notes as unknown as GuitarTuning;
+    }
+  }
 
   return {
     songKey,

--- a/frontend/src/components/ChordDisplay/ChordEdit.tsx
+++ b/frontend/src/components/ChordDisplay/ChordEdit.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ChordEditProps } from './types';
-import { CardContent } from '../ui/card';
 import { Textarea } from '../ui/textarea';
 import ChordEditToolbar from './ChordEditToolbar';
 import StickyBottomContainer from '../StickyBottomContainer';
@@ -13,15 +12,13 @@ const ChordEdit: React.FC<ChordEditProps> = ({ editContent, setEditContent, hand
       <Textarea
         value={editContent}
         onChange={(e) => setEditContent(e.target.value)}
-        className="min-h-[500px] font-mono text-sm resize-none mb-4"
+        className="min-h-[500px] font-mono text-sm resize-none mb-4 !bg-primary/5"
       />
-      <StickyBottomContainer isAtBottom={isAtBottom}>
-        <CardContent className="p-3 sm:p-4">
-          <ChordEditToolbar
-            onSave={handleSaveEdits}
-            onReturn={() => setIsEditing(false)}
-          />
-        </CardContent>
+      <StickyBottomContainer isAtBottom={isAtBottom} className="w-auto ml-0 p-3">
+        <ChordEditToolbar
+          onSave={handleSaveEdits}
+          onReturn={() => setIsEditing(false)}
+        />
       </StickyBottomContainer>
     </div>
   );

--- a/frontend/src/components/ChordDisplay/ChordEdit.tsx
+++ b/frontend/src/components/ChordDisplay/ChordEdit.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { ChordEditProps } from './types';
-import { Textarea } from '../ui/textarea';
-import ChordEditToolbar from './ChordEditToolbar';
-import StickyBottomContainer from '../StickyBottomContainer';
-import { useAtBottom } from '@/hooks/useAtBottom';
+import React from "react";
+import { ChordEditProps } from "./types";
+import { Textarea } from "../ui/textarea";
+import ChordEditToolbar from "./ChordEditToolbar";
+import StickyBottomContainer from "../StickyBottomContainer";
+import { useAtBottom } from "@/hooks/useAtBottom";
 
 const ChordEdit: React.FC<ChordEditProps> = ({ editContent, setEditContent, handleSaveEdits, setIsEditing }) => {
   const isAtBottom = useAtBottom();

--- a/frontend/src/components/ChordDisplay/ChordEdit.tsx
+++ b/frontend/src/components/ChordDisplay/ChordEdit.tsx
@@ -1,25 +1,16 @@
 import React from "react";
 import { ChordEditProps } from "./types";
 import { Textarea } from "../ui/textarea";
-import ChordEditToolbar from "./ChordEditToolbar";
-import StickyBottomContainer from "../StickyBottomContainer";
-import { useAtBottom } from "@/hooks/useAtBottom";
 
-const ChordEdit: React.FC<ChordEditProps> = ({ editContent, setEditContent, handleSaveEdits, setIsEditing }) => {
-  const isAtBottom = useAtBottom();
+const ChordEdit: React.FC<ChordEditProps> = ({ editContent, setEditContent }) => {
   return (
     <div className="w-full mx-auto flex flex-col">
       <Textarea
         value={editContent}
         onChange={(e) => setEditContent(e.target.value)}
-        className="min-h-[500px] font-mono text-sm resize-none mb-4 !bg-primary/5"
+        className="min-h-[500px] font-mono text-sm resize-none !bg-primary/5"
+        autoFocus
       />
-      <StickyBottomContainer isAtBottom={isAtBottom} className="w-auto ml-0 p-3">
-        <ChordEditToolbar
-          onSave={handleSaveEdits}
-          onReturn={() => setIsEditing(false)}
-        />
-      </StickyBottomContainer>
     </div>
   );
 };

--- a/frontend/src/components/ChordDisplay/ChordEditToolbar.tsx
+++ b/frontend/src/components/ChordDisplay/ChordEditToolbar.tsx
@@ -7,21 +7,15 @@ interface ChordEditToolbarProps {
   onReturn: () => void;
 }
 
-/**
- * Toolbar component for the ChordEdit component
- * Contains title, navigation buttons, and save functionality
- */
 const ChordEditToolbar: React.FC<ChordEditToolbarProps> = ({
   onSave,
   onReturn
 }) => {
   return (
-      <div className="flex items-center justify-between">
-        <NavigationButtons 
-          onReturn={onReturn}
-        />
-        <SaveButton onSave={onSave} />
-      </div>
+    <div className="flex items-center justify-between gap-4 w-full">
+      <NavigationButtons onReturn={onReturn} />
+      <SaveButton onSave={onSave} />
+    </div>
   );
 };
 

--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
@@ -4,8 +4,9 @@ import MetadataBadge from "./MetadataBadge";
 import type { ChordMetadataProps } from "./ChordMetadata.types";
 import CapoMenu from "@/components/ChordDisplay/components/StickyControlsBar/CapoMenu";
 import TransposeMenu from "@/components/ChordDisplay/components/StickyControlsBar/TransposeMenu";
+import { Input } from "@/components/ui/input";
 
-const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, controls }) => {
+const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, controls, edit }) => {
   const { t } = useTranslation();
 
   let tuning = t("chordMetadata.standard");
@@ -19,6 +20,47 @@ const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, controls }) =
     chordSheet.guitarCapo !== undefined && chordSheet.guitarCapo !== null
       ? chordSheet.guitarCapo.toString()
       : t("chordMetadata.none");
+
+  if (edit) {
+    return (
+      <div className="w-full text-xs">
+        <div className="px-4 py-2 flex flex-row flex-wrap items-center gap-x-4 gap-y-2">
+          <label className="flex items-center gap-1.5 shrink-0">
+            <span className="font-medium">{t("chordMetadata.guitarTuning")}</span>
+            <Input
+              value={edit.guitarTuning}
+              onChange={(e) => edit.onGuitarTuningChange(e.target.value)}
+              placeholder="E-A-D-G-B-E"
+              aria-label={t("chordMetadata.guitarTuning")}
+              className="h-7 w-32 text-xs"
+            />
+          </label>
+          <label className="flex items-center gap-1.5 shrink-0">
+            <span className="font-medium">{t("chordMetadata.songKey")}</span>
+            <Input
+              value={edit.songKey}
+              onChange={(e) => edit.onSongKeyChange(e.target.value)}
+              placeholder="-"
+              aria-label={t("chordMetadata.songKey")}
+              className="h-7 w-16 text-xs"
+            />
+          </label>
+          <label className="flex items-center gap-1.5 shrink-0">
+            <span className="font-medium">{t("chordMetadata.guitarCapo")}</span>
+            <Input
+              type="number"
+              min={0}
+              max={12}
+              value={edit.guitarCapo}
+              onChange={(e) => edit.onGuitarCapoChange(Number(e.target.value))}
+              aria-label={t("chordMetadata.guitarCapo")}
+              className="h-7 w-16 text-xs"
+            />
+          </label>
+        </div>
+      </div>
+    );
+  }
 
   const keyCapoControls = controls ? (
     <>

--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.tsx
@@ -5,6 +5,7 @@ import type { ChordMetadataProps } from "./ChordMetadata.types";
 import CapoMenu from "@/components/ChordDisplay/components/StickyControlsBar/CapoMenu";
 import TransposeMenu from "@/components/ChordDisplay/components/StickyControlsBar/TransposeMenu";
 import { Input } from "@/components/ui/input";
+import TuningPicker from "./TuningPicker";
 
 const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, controls, edit }) => {
   const { t } = useTranslation();
@@ -27,12 +28,9 @@ const ChordMetadata: React.FC<ChordMetadataProps> = ({ chordSheet, controls, edi
         <div className="px-4 py-2 flex flex-row flex-wrap items-center gap-x-4 gap-y-2">
           <label className="flex items-center gap-1.5 shrink-0">
             <span className="font-medium">{t("chordMetadata.guitarTuning")}</span>
-            <Input
+            <TuningPicker
               value={edit.guitarTuning}
-              onChange={(e) => edit.onGuitarTuningChange(e.target.value)}
-              placeholder="E-A-D-G-B-E"
-              aria-label={t("chordMetadata.guitarTuning")}
-              className="h-7 w-32 text-xs"
+              onChange={edit.onGuitarTuningChange}
             />
           </label>
           <label className="flex items-center gap-1.5 shrink-0">

--- a/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.types.ts
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/ChordMetadata.types.ts
@@ -12,7 +12,17 @@ export interface TransposeCapoControls {
   songKey?: string;
 }
 
+export interface MetadataEditControls {
+  songKey: string;
+  guitarTuning: string;
+  guitarCapo: number;
+  onSongKeyChange: (v: string) => void;
+  onGuitarTuningChange: (v: string) => void;
+  onGuitarCapoChange: (v: number) => void;
+}
+
 export interface ChordMetadataProps {
   chordSheet: ChordSheet;
   controls?: TransposeCapoControls;
+  edit?: MetadataEditControls;
 }

--- a/frontend/src/components/ChordDisplay/ChordMetadata/TuningPicker.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/TuningPicker.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import type { Note } from "@chordium/types";
+import { NOTES } from "@/utils/chord-transposition";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { GUITAR_TUNINGS } from "@/constants/guitar-tunings";
+
+const STANDARD = GUITAR_TUNINGS.STANDARD;
+
+const FLAT_TO_SHARP: Record<string, Note> = {
+  Db: "C#",
+  Eb: "D#",
+  Gb: "F#",
+  Ab: "G#",
+  Bb: "A#",
+};
+
+/** Normalizes a flat-spelled note to its sharp equivalent (dropdowns are sharp-only). */
+function toSharp(note: string): string {
+  return FLAT_TO_SHARP[note] ?? note;
+}
+
+interface TuningPickerProps {
+  /** Hyphen-joined tuning string, low string first (e.g. "E-A-D-G-B-E"). */
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function parseTuning(value: string): string[] {
+  const notes = value.trim().split(/[-\s]+/).filter(Boolean);
+  return Array.from({ length: 6 }, (_, i) => toSharp(notes[i] ?? STANDARD[i]));
+}
+
+/**
+ * Six per-string note selectors, each constrained to the 12 chromatic notes.
+ * Strings are ordered low (6th) to high (1st), matching GuitarTuning.
+ */
+const TuningPicker: React.FC<TuningPickerProps> = ({ value, onChange }) => {
+  const strings = parseTuning(value);
+
+  const handleStringChange = (index: number, note: string) => {
+    const next = [...strings];
+    next[index] = note;
+    onChange(next.join("-"));
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      {strings.map((note, i) => (
+        <Select
+          key={i}
+          value={note}
+          onValueChange={(v) => handleStringChange(i, v)}
+        >
+          <SelectTrigger
+            className="h-7 w-14 text-xs px-2"
+            aria-label={`String ${6 - i}`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NOTES.map((n) => (
+              <SelectItem key={n} value={n}>
+                {n}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ))}
+    </div>
+  );
+};
+
+export default TuningPicker;

--- a/frontend/src/components/ChordDisplay/ChordMetadata/TuningPicker.tsx
+++ b/frontend/src/components/ChordDisplay/ChordMetadata/TuningPicker.tsx
@@ -1,12 +1,11 @@
 import React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
 import type { Note } from "@chordium/types";
 import { NOTES } from "@/utils/chord-transposition";
 import {
   Select,
   SelectContent,
   SelectItem,
-  SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { GUITAR_TUNINGS } from "@/constants/guitar-tunings";
 
@@ -39,6 +38,7 @@ function parseTuning(value: string): string[] {
 /**
  * Six per-string note selectors, each constrained to the 12 chromatic notes.
  * Strings are ordered low (6th) to high (1st), matching GuitarTuning.
+ * Each is a minimal borderless field showing just the note; click opens the dropdown.
  */
 const TuningPicker: React.FC<TuningPickerProps> = ({ value, onChange }) => {
   const strings = parseTuning(value);
@@ -50,20 +50,20 @@ const TuningPicker: React.FC<TuningPickerProps> = ({ value, onChange }) => {
   };
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-0.5">
       {strings.map((note, i) => (
         <Select
           key={i}
           value={note}
           onValueChange={(v) => handleStringChange(i, v)}
         >
-          <SelectTrigger
-            className="h-7 w-14 text-xs px-2"
+          <SelectPrimitive.Trigger
             aria-label={`String ${6 - i}`}
+            className="inline-flex items-center justify-center w-8 h-7 rounded-md border border-input bg-background font-medium text-primary hover:bg-primary/10 focus:outline-hidden focus:ring-1 focus:ring-ring data-[state=open]:ring-1 data-[state=open]:ring-ring transition-colors"
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
+            <SelectPrimitive.Value />
+          </SelectPrimitive.Trigger>
+          <SelectContent className="min-w-[3rem]">
             {NOTES.map((n) => (
               <SelectItem key={n} value={n}>
                 {n}

--- a/frontend/src/components/ChordDisplay/components/StickyControlsBar/StickyControlsBar.tsx
+++ b/frontend/src/components/ChordDisplay/components/StickyControlsBar/StickyControlsBar.tsx
@@ -6,7 +6,7 @@ import { useAtBottom } from "@/hooks/useAtBottom";
 import SpeedControl from "./SpeedControl";
 import PlayButton from "./PlayButton";
 import { Button } from "@/components/ui/button";
-import { ArrowUp, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { ArrowUp, PanelLeftClose, PanelLeftOpen, Pencil } from "lucide-react";
 
 function useAtTop(offset = 10): boolean {
   return useSyncExternalStore(
@@ -24,6 +24,7 @@ const StickyControlsBar: React.FC<ChordSheetControlsProps> = ({
   setAutoScroll,
   scrollSpeed,
   setScrollSpeed,
+  setIsEditing,
 }) => {
   const isAtBottom = useAtBottom({ offset: 60 });
   const isAtTop = useAtTop();
@@ -55,6 +56,17 @@ const StickyControlsBar: React.FC<ChordSheetControlsProps> = ({
         >
           <SpeedControl scrollSpeed={scrollSpeed} setScrollSpeed={setScrollSpeed} />
         </div>
+        {setIsEditing && (
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-10 w-10 rounded-full"
+            onClick={() => setIsEditing(true)}
+            title="Edit chord sheet"
+          >
+            <Pencil size={20} />
+          </Button>
+        )}
         <Button
           variant="outline"
           size="icon"

--- a/frontend/src/components/ChordDisplay/components/StickyControlsBar/StickyControlsBar.tsx
+++ b/frontend/src/components/ChordDisplay/components/StickyControlsBar/StickyControlsBar.tsx
@@ -6,7 +6,7 @@ import { useAtBottom } from "@/hooks/useAtBottom";
 import SpeedControl from "./SpeedControl";
 import PlayButton from "./PlayButton";
 import { Button } from "@/components/ui/button";
-import { ArrowUp, PanelLeftClose, PanelLeftOpen, Pencil } from "lucide-react";
+import { ArrowUp, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 
 function useAtTop(offset = 10): boolean {
   return useSyncExternalStore(
@@ -24,7 +24,6 @@ const StickyControlsBar: React.FC<ChordSheetControlsProps> = ({
   setAutoScroll,
   scrollSpeed,
   setScrollSpeed,
-  setIsEditing,
 }) => {
   const isAtBottom = useAtBottom({ offset: 60 });
   const isAtTop = useAtTop();
@@ -56,17 +55,6 @@ const StickyControlsBar: React.FC<ChordSheetControlsProps> = ({
         >
           <SpeedControl scrollSpeed={scrollSpeed} setScrollSpeed={setScrollSpeed} />
         </div>
-        {setIsEditing && (
-          <Button
-            variant="outline"
-            size="icon"
-            className="h-10 w-10 rounded-full"
-            onClick={() => setIsEditing(true)}
-            title="Edit chord sheet"
-          >
-            <Pencil size={20} />
-          </Button>
-        )}
         <Button
           variant="outline"
           size="icon"

--- a/frontend/src/components/ChordDisplay/types.ts
+++ b/frontend/src/components/ChordDisplay/types.ts
@@ -15,7 +15,6 @@ export interface ChordSheetControlsProps {
   setAutoScroll: (v: boolean) => void;
   scrollSpeed: number;
   setScrollSpeed: (v: number) => void;
-  setIsEditing?: (v: boolean) => void;
   handleDownload?: () => void;
 }
 

--- a/frontend/src/components/ChordSheetViewer.tsx
+++ b/frontend/src/components/ChordSheetViewer.tsx
@@ -22,18 +22,14 @@ interface ChordSheetViewerProps {
   effectiveTranspose?: number;
   fontSize?: number;
   viewMode?: string;
+  // When provided by a parent, editing state is controlled externally
+  isEditing?: boolean;
+  setIsEditing?: (v: boolean) => void;
+  editContent?: string;
+  setEditContent?: (v: string) => void;
+  handleSaveEdits?: () => void;
 }
 
-/**
- * Orchestrates the full chord sheet viewing experience.
- *
- * When `effectiveTranspose` is provided by a parent (e.g. SongViewer), the
- * internal capo/transpose state is unused. Otherwise falls back to the internal
- * state for standalone usage (e.g. UploadTab).
- *
- * The forwarded ref points to the root `#chord-sheet-viewer` div, which parent
- * components (e.g. auto-scroll) use to measure scroll position.
- */
 const ChordSheetViewer = forwardRef<HTMLDivElement, ChordSheetViewerProps>(({
   chordSheet,
   content,
@@ -45,6 +41,11 @@ const ChordSheetViewer = forwardRef<HTMLDivElement, ChordSheetViewerProps>(({
   effectiveTranspose: externalEffectiveTranspose,
   fontSize: externalFontSize,
   viewMode: externalViewMode,
+  isEditing: externalIsEditing,
+  setIsEditing: externalSetIsEditing,
+  editContent: externalEditContent,
+  setEditContent: externalSetEditContent,
+  handleSaveEdits: externalHandleSaveEdits,
 }, ref) => {
 
   const {
@@ -65,22 +66,21 @@ const ChordSheetViewer = forwardRef<HTMLDivElement, ChordSheetViewerProps>(({
   const viewMode = externalViewMode ?? internalViewMode;
   const effectiveTranspose = externalEffectiveTranspose ?? 0;
 
-  const {
-    isEditing,
-    setIsEditing,
-    editContent,
-    setEditContent,
-    updateEditContent,
-    handleSaveEdits: saveEdits
-  } = useChordEditor(content, onSave);
+  const internal = useChordEditor(content, onSave);
 
   useEffect(() => {
-    updateEditContent(content);
-  }, [content, updateEditContent]);
+    internal.updateEditContent(content);
+  }, [content, internal.updateEditContent]);
 
   useEffect(() => {
     onViewModeChange?.(viewMode);
   }, [viewMode, onViewModeChange]);
+
+  const isEditing = externalIsEditing ?? internal.isEditing;
+  const setIsEditing = externalSetIsEditing ?? internal.setIsEditing;
+  const editContent = externalEditContent ?? internal.editContent;
+  const setEditContent = externalSetEditContent ?? internal.setEditContent;
+  const handleSaveEdits = externalHandleSaveEdits ?? internal.handleSaveEdits;
 
   const handleDownload = () => {
     const result = downloadTextFile(content, chordSheet.title || 'chord-sheet');
@@ -92,7 +92,7 @@ const ChordSheetViewer = forwardRef<HTMLDivElement, ChordSheetViewerProps>(({
       <ChordEdit
         editContent={editContent}
         setEditContent={setEditContent}
-        handleSaveEdits={saveEdits}
+        handleSaveEdits={handleSaveEdits}
         setIsEditing={setIsEditing}
       />
     );
@@ -115,7 +115,6 @@ const ChordSheetViewer = forwardRef<HTMLDivElement, ChordSheetViewerProps>(({
           setAutoScroll={toggleAutoScroll}
           scrollSpeed={scrollSpeed}
           setScrollSpeed={setScrollSpeed}
-          setIsEditing={setIsEditing}
           handleDownload={handleDownload}
         />
       )}

--- a/frontend/src/components/PageHeader/PageHeader.types.ts
+++ b/frontend/src/components/PageHeader/PageHeader.types.ts
@@ -10,4 +10,8 @@ export interface PageHeaderProps {
   rightContent?: ReactNode;
   onArtistClick?: () => void;
   metadata?: ReactNode;
+  // Inline editing of title/artist
+  isEditing?: boolean;
+  onTitleChange?: (title: string) => void;
+  onArtistChange?: (artist: string) => void;
 }

--- a/frontend/src/components/PageHeader/TitleSection.tsx
+++ b/frontend/src/components/PageHeader/TitleSection.tsx
@@ -1,30 +1,66 @@
+import { Input } from "@/components/ui/input";
+
 interface TitleSectionProps {
   title?: string;
   artist?: string;
   titleClassName?: string;
   onArtistClick?: () => void;
+  isEditing?: boolean;
+  onTitleChange?: (title: string) => void;
+  onArtistChange?: (artist: string) => void;
 }
 
-const TitleSection = ({ title, artist, titleClassName = "", onArtistClick }: TitleSectionProps) => (
-  title ? (
-    <div className="flex-1 min-w-0 text-left">
-      <h1 className={`text-lg font-semibold truncate ${titleClassName}`} title={title}>
-        {title}
-      </h1>
-      {artist && (
-        onArtistClick ? (
-          <button
-            onClick={onArtistClick}
-            className="text-sm text-primary truncate block max-w-full hover:underline focus:underline focus:outline-none text-left"
-          >
-            {artist}
-          </button>
-        ) : (
-          <p className="text-sm text-muted-foreground truncate">{artist}</p>
-        )
-      )}
-    </div>
-  ) : null
-);
+const TitleSection = ({
+  title,
+  artist,
+  titleClassName = "",
+  onArtistClick,
+  isEditing = false,
+  onTitleChange,
+  onArtistChange,
+}: TitleSectionProps) => {
+  if (isEditing) {
+    return (
+      <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+        <Input
+          value={title ?? ""}
+          onChange={(e) => onTitleChange?.(e.target.value)}
+          placeholder="Title"
+          aria-label="Song title"
+          className="h-8 text-lg font-semibold"
+        />
+        <Input
+          value={artist ?? ""}
+          onChange={(e) => onArtistChange?.(e.target.value)}
+          placeholder="Artist"
+          aria-label="Artist"
+          className="h-7 text-sm"
+        />
+      </div>
+    );
+  }
+
+  return (
+    title ? (
+      <div className="flex-1 min-w-0 text-left">
+        <h1 className={`text-lg font-semibold truncate ${titleClassName}`} title={title}>
+          {title}
+        </h1>
+        {artist && (
+          onArtistClick ? (
+            <button
+              onClick={onArtistClick}
+              className="text-sm text-primary truncate block max-w-full hover:underline focus:underline focus:outline-none text-left"
+            >
+              {artist}
+            </button>
+          ) : (
+            <p className="text-sm text-muted-foreground truncate">{artist}</p>
+          )
+        )}
+      </div>
+    ) : null
+  );
+};
 
 export default TitleSection;

--- a/frontend/src/components/PageHeader/index.tsx
+++ b/frontend/src/components/PageHeader/index.tsx
@@ -16,6 +16,9 @@ const PageHeader = memo(({
   onArtistClick,
   rightContent,
   metadata,
+  isEditing = false,
+  onTitleChange,
+  onArtistChange,
 }: PageHeaderProps) => {
   return (
     <Card className="rounded-lg border bg-card text-card-foreground shadow-xs overflow-hidden">
@@ -23,7 +26,15 @@ const PageHeader = memo(({
         <div className="shrink-0">
           <BackButton onBack={onBack} />
         </div>
-        <TitleSection title={title} artist={artist} titleClassName={titleClassName} onArtistClick={onArtistClick} />
+        <TitleSection
+          title={title}
+          artist={artist}
+          titleClassName={titleClassName}
+          onArtistClick={onArtistClick}
+          isEditing={isEditing}
+          onTitleChange={onTitleChange}
+          onArtistChange={onArtistChange}
+        />
         <div className="flex items-center gap-2 shrink-0 min-w-8 ml-auto sm:ml-0">
           {isSaved === true && onAction && <DeleteButton onDelete={onAction} />}
           {isSaved === false && onAction && <SaveButton onSave={onAction} />}

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -9,9 +9,12 @@ import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArt
 import type { Song } from "../types/song";
 import type { ChordSheet, SongMetadata } from "@/types/chordSheet";
 import { useLazyChordSheet } from "@/storage/hooks/use-lazy-chord-sheet";
-import { JamQRModal } from "@/features/jam-session/components/JamQRModal";
 import { useChordDisplaySettings } from "@/hooks/use-chord-display-settings";
 import { useCapoTranspose } from "@/hooks/useCapoTranspose";
+import { useChordEditor } from "@/hooks/use-chord-editor";
+import { Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { JamQRModal } from "@/features/jam-session/components/JamQRModal";
 
 interface SongViewerProps {
   song: { song: Song; chordSheet: ChordSheet & SongMetadata };
@@ -52,16 +55,16 @@ const SongViewer = ({
   const navigate = useNavigate();
 
   const [fontSize, setFontSize] = useState(14);
-  const [viewMode, setViewMode] = useState(initialViewMode || 'tabs-on');
+  const [viewMode, setViewMode] = useState(initialViewMode || "tabs-on");
 
   const { content: lazyContent, isContentLoading: isLazyContentLoading } = useLazyChordSheet({
-    path: isFromMyChordSheets ? songObj.path : ''
+    path: isFromMyChordSheets ? songObj.path : "",
   });
 
   const chordContentToDisplay = useMemo(() => {
     if (directChordContent) return directChordContent;
-    if (isFromMyChordSheets) return lazyContent || '';
-    return chordSheet.songChords || '';
+    if (isFromMyChordSheets) return lazyContent || "";
+    return chordSheet.songChords || "";
   }, [directChordContent, isFromMyChordSheets, lazyContent, chordSheet.songChords]);
 
   const chordSheetToDisplay = useMemo(() => chordSheet, [chordSheet]);
@@ -73,7 +76,12 @@ const SongViewer = ({
     capo,
     setCapo,
     defaultCapo,
-  } = useChordDisplaySettings(chordContentToDisplay, chordSheetToDisplay.songKey, chordSheetToDisplay.guitarCapo, initialViewMode);
+  } = useChordDisplaySettings(
+    chordContentToDisplay,
+    chordSheetToDisplay.songKey,
+    chordSheetToDisplay.guitarCapo,
+    initialViewMode
+  );
 
   const {
     handleCapoChange,
@@ -84,8 +92,19 @@ const SongViewer = ({
 
   const effectiveTranspose = transpose - (capo - defaultCapo);
 
+  const {
+    isEditing,
+    setIsEditing,
+    editContent,
+    setEditContent,
+    updateEditContent,
+    handleSaveEdits: saveEdits,
+  } = useChordEditor(chordContentToDisplay, onUpdate);
+
   const handleAction = () => {
-    if (isFromMyChordSheets && !hideDeleteButton) {
+    if (isEditing) {
+      saveEdits();
+    } else if (isFromMyChordSheets && !hideDeleteButton) {
       onDelete(songObj.path);
     } else if (!hideSaveButton && !isFromMyChordSheets && onSave) {
       onSave();
@@ -93,8 +112,14 @@ const SongViewer = ({
   };
 
   const shouldShowActionButton =
+    isEditing ||
     (isFromMyChordSheets && !hideDeleteButton) ||
     (!hideSaveButton && !isFromMyChordSheets && !!onSave);
+
+  // isSaved controls which icon the action button shows:
+  // true = trash (delete), false = save disk icon
+  // When editing, show the save icon (false)
+  const isSaved = isEditing ? false : isFromMyChordSheets && !hideDeleteButton;
 
   const finalIsContentLoading = useProgressiveLoading
     ? isContentLoading
@@ -112,24 +137,43 @@ const SongViewer = ({
     const artistSlug = songObj.path.split("/")[0];
     sessionStorage.removeItem("chordium_search_query");
     try {
-      sessionStorage.setItem(ARTIST_DISPLAY_NAME_KEY, JSON.stringify({ path: artistSlug, displayName: artist }));
+      sessionStorage.setItem(
+        ARTIST_DISPLAY_NAME_KEY,
+        JSON.stringify({ path: artistSlug, displayName: artist })
+      );
     } catch {}
     navigate(`/${artistSlug}`);
   }, [artist, navigate, songObj.path]);
 
   return (
-    <main id="page-chord-viewer" className="flex-1 w-full max-w-3xl mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4">
+    <main
+      id="page-chord-viewer"
+      className="flex-1 w-full max-w-3xl mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4"
+    >
       <PageHeader
         onBack={onBack}
-        onAction={shouldShowActionButton && handleAction}
-        isSaved={shouldShowActionButton && isFromMyChordSheets}
+        onAction={shouldShowActionButton ? handleAction : undefined}
+        isSaved={isSaved}
         title={title}
         artist={artist}
         onArtistClick={artist ? handleArtistClick : undefined}
         rightContent={
-          chordContentToDisplay && (
-            <JamQRModal chordSheet={{ ...chordSheetToDisplay, songChords: chordContentToDisplay }} />
-          )
+          <>
+            {!isEditing && chordContentToDisplay && (
+              <JamQRModal
+                chordSheet={{ ...chordSheetToDisplay, songChords: chordContentToDisplay }}
+              />
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-shrink-0 h-10 w-10 rounded-full"
+              onClick={() => setIsEditing((e) => !e)}
+              title={isEditing ? "Cancel editing" : "Edit chord sheet"}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+          </>
         }
         metadata={
           <ChordMetadata
@@ -166,6 +210,11 @@ const SongViewer = ({
         effectiveTranspose={effectiveTranspose}
         fontSize={fontSize}
         viewMode={viewMode}
+        isEditing={isEditing}
+        setIsEditing={setIsEditing}
+        editContent={editContent}
+        setEditContent={setEditContent}
+        handleSaveEdits={saveEdits}
       />
     </main>
   );

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -15,6 +15,16 @@ import { useChordEditor } from "@/hooks/use-chord-editor";
 import { Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { JamQRModal } from "@/features/jam-session/components/JamQRModal";
+import { guitarTuningToString, mapStringToGuitarTuning } from "@/utils/guitar-tuning-utils";
+
+export interface UpdatedSongData {
+  songChords: string;
+  title: string;
+  artist: string;
+  songKey: string;
+  guitarTuning: ChordSheet["guitarTuning"];
+  guitarCapo: number;
+}
 
 interface SongViewerProps {
   song: { song: Song; chordSheet: ChordSheet & SongMetadata };
@@ -23,7 +33,7 @@ interface SongViewerProps {
   onBack: () => void;
   onDelete: (songPath: string) => void;
   onSave?: () => void;
-  onUpdate: (content: string) => void;
+  onUpdate: (data: UpdatedSongData) => void;
   hideDeleteButton?: boolean;
   hideSaveButton?: boolean;
   isFromMyChordSheets?: boolean;
@@ -92,6 +102,27 @@ const SongViewer = ({
 
   const effectiveTranspose = transpose - (capo - defaultCapo);
 
+  // Editable metadata buffer (title/artist/key/tuning/capo).
+  const [editTitle, setEditTitle] = useState(chordSheetToDisplay.title ?? "");
+  const [editArtist, setEditArtist] = useState(chordSheetToDisplay.artist ?? "");
+  const [editSongKey, setEditSongKey] = useState(chordSheetToDisplay.songKey ?? "");
+  const [editTuning, setEditTuning] = useState(guitarTuningToString(chordSheetToDisplay.guitarTuning));
+  const [editCapo, setEditCapo] = useState(chordSheetToDisplay.guitarCapo ?? 0);
+
+  const handleSaveWithMeta = useCallback(
+    (content: string) => {
+      onUpdate({
+        songChords: content,
+        title: editTitle || "Untitled Song",
+        artist: editArtist || "Unknown Artist",
+        songKey: editSongKey,
+        guitarTuning: mapStringToGuitarTuning(editTuning),
+        guitarCapo: editCapo,
+      });
+    },
+    [onUpdate, editTitle, editArtist, editSongKey, editTuning, editCapo]
+  );
+
   const {
     isEditing,
     setIsEditing,
@@ -99,13 +130,19 @@ const SongViewer = ({
     setEditContent,
     updateEditContent,
     handleSaveEdits: saveEdits,
-  } = useChordEditor(chordContentToDisplay, onUpdate);
+  } = useChordEditor(chordContentToDisplay, handleSaveWithMeta);
 
-  // Keep the editor buffer in sync with displayed content while not editing,
-  // so re-opening the editor shows the latest (possibly just-saved) text.
+  // Keep the editor buffers in sync with displayed content/metadata while not
+  // editing, so re-opening the editor shows the latest (possibly just-saved) values.
   useEffect(() => {
-    if (!isEditing) updateEditContent(chordContentToDisplay);
-  }, [chordContentToDisplay, isEditing, updateEditContent]);
+    if (isEditing) return;
+    updateEditContent(chordContentToDisplay);
+    setEditTitle(chordSheetToDisplay.title ?? "");
+    setEditArtist(chordSheetToDisplay.artist ?? "");
+    setEditSongKey(chordSheetToDisplay.songKey ?? "");
+    setEditTuning(guitarTuningToString(chordSheetToDisplay.guitarTuning));
+    setEditCapo(chordSheetToDisplay.guitarCapo ?? 0);
+  }, [chordContentToDisplay, chordSheetToDisplay, isEditing, updateEditContent]);
 
   const handleAction = () => {
     if (isEditing) {
@@ -136,8 +173,8 @@ const SongViewer = ({
     onViewModeChange?.(mode);
   };
 
-  const title = chordSheetToDisplay.title;
-  const artist = chordSheetToDisplay.artist;
+  const title = isEditing ? editTitle : chordSheetToDisplay.title;
+  const artist = isEditing ? editArtist : chordSheetToDisplay.artist;
 
   const handleArtistClick = useCallback(() => {
     const artistSlug = songObj.path.split("/")[0];
@@ -162,7 +199,10 @@ const SongViewer = ({
         isSaved={isSaved}
         title={title}
         artist={artist}
-        onArtistClick={artist ? handleArtistClick : undefined}
+        onArtistClick={!isEditing && artist ? handleArtistClick : undefined}
+        isEditing={isEditing}
+        onTitleChange={setEditTitle}
+        onArtistChange={setEditArtist}
         rightContent={
           <>
             {!isEditing && chordContentToDisplay && (
@@ -184,7 +224,7 @@ const SongViewer = ({
         metadata={
           <ChordMetadata
             chordSheet={chordSheetToDisplay}
-            controls={{
+            controls={isEditing ? undefined : {
               transpose,
               defaultTranspose,
               handleTransposeChange,
@@ -195,6 +235,14 @@ const SongViewer = ({
               getCapoDisableStates,
               songKey: chordSheetToDisplay.songKey,
             }}
+            edit={isEditing ? {
+              songKey: editSongKey,
+              guitarTuning: editTuning,
+              guitarCapo: editCapo,
+              onSongKeyChange: setEditSongKey,
+              onGuitarTuningChange: setEditTuning,
+              onGuitarCapoChange: setEditCapo,
+            } : undefined}
           />
         }
       />
@@ -211,7 +259,6 @@ const SongViewer = ({
         ref={chordDisplayRef}
         chordSheet={chordSheetToDisplay}
         content={chordContentToDisplay}
-        onSave={onUpdate}
         isLoading={finalIsContentLoading}
         effectiveTranspose={effectiveTranspose}
         fontSize={fontSize}

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -3,7 +3,7 @@ import PageHeader from "@/components/PageHeader";
 import ChordMetadata from "@/components/ChordDisplay/ChordMetadata";
 import StyleToolbar from "@/components/StyleToolbar";
 import { Card } from "@/components/ui/card";
-import { RefObject, useCallback, useMemo, useState } from "react";
+import { RefObject, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArtist";
 import type { Song } from "../types/song";
@@ -100,6 +100,12 @@ const SongViewer = ({
     updateEditContent,
     handleSaveEdits: saveEdits,
   } = useChordEditor(chordContentToDisplay, onUpdate);
+
+  // Keep the editor buffer in sync with displayed content while not editing,
+  // so re-opening the editor shows the latest (possibly just-saved) text.
+  useEffect(() => {
+    if (!isEditing) updateEditContent(chordContentToDisplay);
+  }, [chordContentToDisplay, isEditing, updateEditContent]);
 
   const handleAction = () => {
     if (isEditing) {

--- a/frontend/src/components/TabContainer.tsx
+++ b/frontend/src/components/TabContainer.tsx
@@ -14,7 +14,7 @@ import { deleteChordSheet, storeChordSheet } from "@/storage/stores/chord-sheets
 import { toast } from "sonner";
 import { cyAttr } from "@/utils/test-utils";
 import { toSlug } from "@/utils/url-slug-utils";
-import { GUITAR_TUNINGS } from "@/constants/guitar-tunings";
+import { mapStringToGuitarTuning } from "@/utils/guitar-tuning-utils";
 import i18n from "@/i18n/config";
 
 interface TabContainerProps {
@@ -100,20 +100,6 @@ const TabContainer = ({
       });
     }
   };
-
-  function mapStringToGuitarTuning(tuning: string) {
-    const normalized = tuning.trim().toLowerCase();
-    for (const key in GUITAR_TUNINGS) {
-      if (
-        key.toLowerCase() === normalized ||
-        GUITAR_TUNINGS[key as keyof typeof GUITAR_TUNINGS].join("-").toLowerCase() ===
-          normalized.replace(/\s+/g, "-")
-      ) {
-        return GUITAR_TUNINGS[key as keyof typeof GUITAR_TUNINGS];
-      }
-    }
-    return GUITAR_TUNINGS.STANDARD;
-  }
 
   const handleSaveUploadedChordSheet = async (meta: {
     content: string;

--- a/frontend/src/components/tabs/UploadTab.tsx
+++ b/frontend/src/components/tabs/UploadTab.tsx
@@ -4,7 +4,7 @@ import FileUploader from "@/components/FileUploader";
 import ChordSheetViewer from "@/components/ChordSheetViewer";
 
 import ChordEditToolbar from "@/components/ChordDisplay/ChordEditToolbar";
-import { GUITAR_TUNINGS } from "@/constants/guitar-tunings";
+import { mapStringToGuitarTuning } from "@/utils/guitar-tuning-utils";
 import { extractSongMetadata } from "@/utils/metadata-extraction";
 import { ChordSheet } from "@chordium/types";
 
@@ -75,20 +75,6 @@ const UploadTab = ({ chordDisplayRef, onSaveUploadedSong }: UploadTabProps) => {
       setShowMetadata(false);
     }
   };
-
-  // Map string tuning to GuitarTuning array for preview
-  function mapStringToGuitarTuning(tuning: string) {
-    const normalized = tuning.trim().toLowerCase();
-    for (const key in GUITAR_TUNINGS) {
-      if (
-        key.toLowerCase() === normalized ||
-        GUITAR_TUNINGS[key as keyof typeof GUITAR_TUNINGS].join('-').toLowerCase() === normalized.replace(/\s+/g, '-')
-      ) {
-        return GUITAR_TUNINGS[key as keyof typeof GUITAR_TUNINGS];
-      }
-    }
-    return GUITAR_TUNINGS.STANDARD;
-  }
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6">

--- a/frontend/src/components/tabs/UploadTab.tsx
+++ b/frontend/src/components/tabs/UploadTab.tsx
@@ -121,6 +121,11 @@ const UploadTab = ({ chordDisplayRef, onSaveUploadedSong }: UploadTabProps) => {
             }}
             content={uploadedContent}
             showControlsBar={false}
+            isEditing={true}
+            setIsEditing={() => {}}
+            editContent={uploadedContent}
+            setEditContent={setUploadedContent}
+            handleSaveEdits={handleSave}
           />
         </div>
       )}

--- a/frontend/src/components/ui/file-info.tsx
+++ b/frontend/src/components/ui/file-info.tsx
@@ -1,5 +1,4 @@
-import { FileUp, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { FileUp } from 'lucide-react';
 import RoundTrashButton from './RoundTrashButton';
 
 interface FileInfoProps {
@@ -14,15 +13,7 @@ const FileInfo = ({ fileName, onRemoveFile }: FileInfoProps) => {
         <FileUp className="h-5 w-5 text-primary shrink-0" />
         <span className="font-medium truncate">{fileName}</span>
       </div>
-      <Button 
-        variant="ghost" 
-        size="sm"
-        onClick={onRemoveFile}
-        className="h-8 w-8 p-0"
-      >
-        <RoundTrashButton />
-        <span className="sr-only">Remove</span>
-      </Button>
+      <RoundTrashButton label="Remove" onClick={onRemoveFile} />
     </div>
   );
 };

--- a/frontend/src/hooks/use-chord-editor.ts
+++ b/frontend/src/hooks/use-chord-editor.ts
@@ -2,12 +2,6 @@ import { useState } from "react";
 import { toast } from "sonner";
 import i18n from "@/i18n/config";
 
-/**
- * Custom hook to manage chord sheet editing
- * @param initialContent The initial chord sheet content
- * @param onSave Optional callback for saving edited content
- * @returns Editing state and handlers
- */
 export const useChordEditor = (
   initialContent: string,
   onSave?: (content: string) => void
@@ -24,8 +18,7 @@ export const useChordEditor = (
       onSave(editContent);
     }
     setIsEditing(false);
-    toast({
-      title: i18n.t("notifications:changesSaved"),
+    toast.success(i18n.t("notifications:changesSaved"), {
       description: i18n.t("notifications:changesSavedDesc"),
     });
   };

--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
 import { useParams, useLocation, useSearchParams } from 'react-router-dom';
-import SongViewer from '@/components/SongViewer';
+import SongViewer, { type UpdatedSongData } from '@/components/SongViewer';
 import { useChordSheetWithFallback } from '@/hooks/useChordSheetWithFallback';
 import type { RouteParams } from './chord-viewer.types';
 
@@ -29,11 +29,11 @@ const ChordViewer = () => {
   const [searchParams] = useSearchParams();
   const [jamPayload, setJamPayload] = useState<JamPayload | null>(null);
 
-  // Holds edited chord content so the view reflects saves without a page refresh.
-  const [editedContent, setEditedContent] = useState<string | null>(null);
+  // Holds edited song data so the view reflects saves without a page refresh.
+  const [editedData, setEditedData] = useState<UpdatedSongData | null>(null);
 
   useEffect(() => {
-    setEditedContent(null);
+    setEditedData(null);
   }, [path]);
 
   useEffect(() => {
@@ -108,17 +108,21 @@ const ChordViewer = () => {
     chordSheetData?.chordSheet.title ?? 'Chord Sheet'
   );
 
-  const handleUpdate = useCallback(async (updatedContent: string) => {
-    if (!chordSheetData) return;
-    const { title, artist, songKey, guitarTuning, guitarCapo } = chordSheetData.chordSheet;
+  const handleUpdate = useCallback(async (data: UpdatedSongData) => {
     await storeChordSheet(
-      { title, artist, songKey, guitarTuning, guitarCapo },
-      { songChords: updatedContent },
+      {
+        title: data.title,
+        artist: data.artist,
+        songKey: data.songKey,
+        guitarTuning: data.guitarTuning,
+        guitarCapo: data.guitarCapo,
+      },
+      { songChords: data.songChords },
       isSaved,
       path
     );
-    setEditedContent(updatedContent);
-  }, [chordSheetData, isSaved, path]);
+    setEditedData(data);
+  }, [isSaved, path]);
 
   if (jamPayload && !chordSheetResult.metadata) {
     const jamChordSheet = {
@@ -168,20 +172,29 @@ const ChordViewer = () => {
     );
   }
 
-  const displayContent = editedContent ?? (chordSheetResult.content?.songChords ?? '');
+  const displayContent = editedData?.songChords ?? (chordSheetResult.content?.songChords ?? '');
 
-  // When an edit has been made, the edited plain text becomes the source of
-  // truth; drop the stale scraped rawHtml so the new content renders.
-  const displayChordSheet = editedContent != null
-    ? { ...chordSheetData!.chordSheet, songChords: editedContent, rawHtml: undefined }
+  // Once edited, the edited plain text/metadata become the source of truth;
+  // drop the stale scraped rawHtml so the new content renders.
+  const displayChordSheet = editedData != null
+    ? {
+        ...chordSheetData!.chordSheet,
+        title: editedData.title,
+        artist: editedData.artist,
+        songKey: editedData.songKey,
+        guitarTuning: editedData.guitarTuning,
+        guitarCapo: editedData.guitarCapo,
+        songChords: editedData.songChords,
+        rawHtml: undefined,
+      }
     : chordSheetData!.chordSheet;
 
   return (
     <SongViewer
       song={{
         song: {
-          title: chordSheetData!.chordSheet.title,
-          artist: chordSheetData!.chordSheet.artist,
+          title: displayChordSheet.title,
+          artist: displayChordSheet.artist,
           path: chordSheetData!.path
         },
         chordSheet: displayChordSheet

--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -11,6 +11,7 @@ import { extractNavigationData } from './utils/navigation-data';
 
 import { useNavigation } from '@/hooks/navigation';
 import { useChordSheetSave, useChordSheetDelete } from '@/storage/hooks';
+import storeChordSheet from '@/storage/stores/chord-sheets/operations/store-chord-sheet';
 
 import { ChordViewerLoading } from './components/chord-viewer-loading';
 import { ChordViewerError } from './components/chord-viewer-error';
@@ -27,6 +28,13 @@ const ChordViewer = () => {
 
   const [searchParams] = useSearchParams();
   const [jamPayload, setJamPayload] = useState<JamPayload | null>(null);
+
+  // Holds edited chord content so the view reflects saves without a page refresh.
+  const [editedContent, setEditedContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEditedContent(null);
+  }, [path]);
 
   useEffect(() => {
     const d = searchParams.get('d');
@@ -100,6 +108,18 @@ const ChordViewer = () => {
     chordSheetData?.chordSheet.title ?? 'Chord Sheet'
   );
 
+  const handleUpdate = useCallback(async (updatedContent: string) => {
+    if (!chordSheetData) return;
+    const { title, artist, songKey, guitarTuning, guitarCapo } = chordSheetData.chordSheet;
+    await storeChordSheet(
+      { title, artist, songKey, guitarTuning, guitarCapo },
+      { songChords: updatedContent },
+      isSaved,
+      path
+    );
+    setEditedContent(updatedContent);
+  }, [chordSheetData, isSaved, path]);
+
   if (jamPayload && !chordSheetResult.metadata) {
     const jamChordSheet = {
       title: jamPayload.title,
@@ -148,7 +168,13 @@ const ChordViewer = () => {
     );
   }
 
-  const displayContent = chordSheetResult.content?.songChords ?? '';
+  const displayContent = editedContent ?? (chordSheetResult.content?.songChords ?? '');
+
+  // When an edit has been made, the edited plain text becomes the source of
+  // truth; drop the stale scraped rawHtml so the new content renders.
+  const displayChordSheet = editedContent != null
+    ? { ...chordSheetData!.chordSheet, songChords: editedContent, rawHtml: undefined }
+    : chordSheetData!.chordSheet;
 
   return (
     <SongViewer
@@ -158,14 +184,14 @@ const ChordViewer = () => {
           artist: chordSheetData!.chordSheet.artist,
           path: chordSheetData!.path
         },
-        chordSheet: chordSheetData!.chordSheet
+        chordSheet: displayChordSheet
       }}
       chordContent={displayContent}
       chordDisplayRef={chordDisplayRef}
       onBack={handleBack}
       onDelete={handleDelete}
       onSave={handleSave}
-      onUpdate={() => {}}
+      onUpdate={handleUpdate}
       hideDeleteButton={!isSaved}
       hideSaveButton={isSaved}
       isFromMyChordSheets={isSaved}

--- a/frontend/src/storage/data/samples/chord-sheets/metadata/extreme-more_than_words.json
+++ b/frontend/src/storage/data/samples/chord-sheets/metadata/extreme-more_than_words.json
@@ -1,7 +1,7 @@
 {
   "title": "More Than Words",
   "artist": "Extreme",
-  "songKey": "G",
-  "guitarTuning": ["E", "A", "D", "G", "B", "E"],
+  "songKey": "F#",
+  "guitarTuning": ["Eb", "Ab", "Db", "Gb", "Bb", "Eb"],
   "guitarCapo": 0
 }

--- a/frontend/src/storage/services/sample-chord-sheets/duplicate-prevention.ts
+++ b/frontend/src/storage/services/sample-chord-sheets/duplicate-prevention.ts
@@ -5,7 +5,7 @@
 import type { IChordSheetStorage } from './types';
 
 const SAMPLE_VERSION_KEY = 'chordium-sample-version';
-const CURRENT_SAMPLE_VERSION = '5';
+const CURRENT_SAMPLE_VERSION = '6';
 
 /**
  * Determines if sample chord sheets should be loaded into storage

--- a/frontend/src/utils/guitar-tuning-utils.ts
+++ b/frontend/src/utils/guitar-tuning-utils.ts
@@ -1,0 +1,32 @@
+import { GUITAR_TUNINGS, type GuitarTuning } from "@/constants/guitar-tunings";
+
+/**
+ * Converts a free-form tuning string (e.g. "E-A-D-G-B-E" or "Drop D") into a
+ * GuitarTuning tuple. Falls back to STANDARD when it can't be parsed into 6 notes.
+ */
+export function mapStringToGuitarTuning(tuning: string): GuitarTuning {
+  const normalized = tuning.trim().toLowerCase();
+
+  for (const key in GUITAR_TUNINGS) {
+    const known = GUITAR_TUNINGS[key as keyof typeof GUITAR_TUNINGS];
+    if (
+      key.toLowerCase() === normalized ||
+      known.join("-").toLowerCase() === normalized.replace(/\s+/g, "-")
+    ) {
+      return known;
+    }
+  }
+
+  const notes = tuning.trim().split(/[-\s]+/).filter(Boolean);
+  if (notes.length === 6) {
+    return notes as unknown as GuitarTuning;
+  }
+
+  return GUITAR_TUNINGS.STANDARD;
+}
+
+/** Formats a GuitarTuning (or string) for display/editing as "E-A-D-G-B-E". */
+export function guitarTuningToString(tuning: GuitarTuning | string | undefined): string {
+  if (!tuning) return "";
+  return Array.isArray(tuning) ? tuning.join("-") : tuning;
+}

--- a/shared/fixtures/chord-sheet/metadata/extreme-more_than_words.json
+++ b/shared/fixtures/chord-sheet/metadata/extreme-more_than_words.json
@@ -1,7 +1,7 @@
 {
   "title": "More Than Words",
   "artist": "Extreme",
-  "songKey": "G",
-  "guitarTuning": ["E", "A", "D", "G", "B", "E"],
+  "songKey": "F#",
+  "guitarTuning": ["Eb", "Ab", "Db", "Gb", "Bb", "Eb"],
   "guitarCapo": 0
 }


### PR DESCRIPTION
## Summary

Re-enables chord sheet editing and makes song metadata editable, plus improves tuning accuracy.

- **Edit chord sheets** — pencil in the song header toggles edit mode; the delete button becomes save while editing. Uploaded sheets open directly in edit mode. Edits persist and display without a page refresh.
- **Editable metadata** — title, artist, key, capo, and tuning are editable inline in the header. Tuning uses per-string note pickers constrained to valid notes.
- **Accurate tuning on fetch** — guitar tuning is now read from the source page metadata instead of always defaulting to standard.

## Test plan

- [ ] Open a saved song → click the pencil → edit content and metadata → save → changes persist after reload
- [ ] Cancel editing (pencil again) restores the read view without saving
- [ ] Upload a chord sheet → it opens in edit mode → save works
- [ ] Tuning picker: each string only offers valid notes; changes save and round-trip
- [ ] Fetch a fresh song with a non-standard tuning → tuning shows correctly (not standard)
- [ ] Editing does not alter the song's path / cache key / displayed identity
