### PR TITLE
fix: correct artist display name casing (e.g. Ac Dc to AC/DC)

### DIFF
--- a/backend/tests/integration/data-transformation-pipeline/artist-songs-pipeline.test.ts
+++ b/backend/tests/integration/data-transformation-pipeline/artist-songs-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from '@jest/globals';
 import { extractArtistSongs } from '../../../utils/dom-extractors.js';
 import { transformToSongResults } from '../../../utils/result-transformers.js';
-import { mockDocument, cleanupDOM, type MockLink } from './shared-test-utils.js';
+import { cleanupDOM } from './shared-test-utils.js';
 import type { BasicSearchResult } from '../../../../shared/types/index.js';
 
 /**
@@ -9,29 +9,38 @@ import type { BasicSearchResult } from '../../../../shared/types/index.js';
  * Validates extraction and transformation of artist-specific song lists
  */
 
+function mockArtistSongsDOM(links: { href: string; primaryLabel: string }[], artistName: string): void {
+  const testGlobal = global as unknown as {
+    document: { querySelectorAll: (s: string) => unknown[]; querySelector: (s: string) => unknown; title: string };
+    window: { location: { origin: string; pathname: string } };
+  };
+  testGlobal.document = {
+    querySelectorAll: (selector: string) =>
+      selector === 'ol li a[href]'
+        ? links.map((l) => ({
+            getAttribute: (name: string) => (name === 'href' ? l.href : null),
+            querySelector: (s: string) => (s === "p[class*='primaryLabel']" ? { textContent: l.primaryLabel } : null),
+          }))
+        : [],
+    querySelector: (selector: string) => (selector === 'h2.t3 a' ? { textContent: artistName } : null),
+    title: '',
+  };
+  testGlobal.window = { location: { origin: 'https://www.cifraclub.com.br', pathname: '/oasis/' } };
+}
+
 describe('Artist Songs Pipeline', () => {
   afterEach(() => {
     cleanupDOM();
   });
 
   it('should extract artist songs with url field and maintain consistency', () => {
-    const mockLinks: MockLink[] = [
-      {
-        textContent: 'Wonderwall',
-        href: 'https://www.cifraclub.com.br/oasis/wonderwall/'
-      },
-      {
-        textContent: 'Don\'t Look Back in Anger',
-        href: 'https://www.cifraclub.com.br/oasis/dont-look-back-in-anger/'
-      }
-    ];
-
-    mockDocument((selector) => {
-      if (selector === 'a.art_music-link') {
-        return mockLinks;
-      }
-      return [];
-    }, 'Oasis - Cifra Club');
+    mockArtistSongsDOM(
+      [
+        { href: '/oasis/wonderwall/', primaryLabel: 'Wonderwall' },
+        { href: '/oasis/dont-look-back-in-anger/', primaryLabel: "Don't Look Back in Anger" },
+      ],
+      'Oasis'
+    );
 
     // Step 1: DOM extraction for artist songs
     const rawResults = extractArtistSongs();

--- a/backend/tests/integration/data-transformation-pipeline/unified-interface-validation.test.ts
+++ b/backend/tests/integration/data-transformation-pipeline/unified-interface-validation.test.ts
@@ -4,6 +4,25 @@ import { transformToSongResults } from '../../../utils/result-transformers.js';
 import { mockDocument, cleanupDOM, type MockLink, expectedSongInterface } from './shared-test-utils.js';
 import type { BasicSearchResult } from '../../../../shared/types/index.js';
 
+function mockArtistSongsDOM(links: { href: string; primaryLabel: string }[], artistName: string): void {
+  const testGlobal = global as unknown as {
+    document: { querySelectorAll: (s: string) => unknown[]; querySelector: (s: string) => unknown; title: string };
+    window: { location: { origin: string; pathname: string } };
+  };
+  testGlobal.document = {
+    querySelectorAll: (selector: string) =>
+      selector === 'ol li a[href]'
+        ? links.map((l) => ({
+            getAttribute: (name: string) => (name === 'href' ? l.href : null),
+            querySelector: (s: string) => (s === "p[class*='primaryLabel']" ? { textContent: l.primaryLabel } : null),
+          }))
+        : [],
+    querySelector: (selector: string) => (selector === 'h2.t3 a' ? { textContent: artistName } : null),
+    title: '',
+  };
+  testGlobal.window = { location: { origin: 'https://www.cifraclub.com.br', pathname: '/test-artist/' } };
+}
+
 /**
  * Tests for unified Song interface validation across different data sources
  * Ensures consistency between search results and artist song results
@@ -24,14 +43,6 @@ describe('Unified Song Interface Validation', () => {
       }
     ];
 
-    // Mock artist songs
-    const artistSongsMockLinks: MockLink[] = [
-      {
-        textContent: 'Test Song',
-        href: 'https://www.cifraclub.com.br/test-artist/test-song/'
-      }
-    ];
-
     // Test search results
     mockDocument((selector) => {
       if (selector === '.gsc-result a') {
@@ -44,12 +55,7 @@ describe('Unified Song Interface Validation', () => {
     const searchFinalResults = transformToSongResults(searchRawResults as unknown as BasicSearchResult[]);
 
     // Test artist songs
-    mockDocument((selector) => {
-      if (selector === 'a.art_music-link') {
-        return artistSongsMockLinks;
-      }
-      return [];
-    }, 'Test Artist - Cifra Club');
+    mockArtistSongsDOM([{ href: '/test-artist/test-song/', primaryLabel: 'Test Song' }], 'Test Artist');
 
     const artistSongsRawResults = extractArtistSongs();
     const artistSongsFinalResults = transformToSongResults(artistSongsRawResults as unknown as BasicSearchResult[]);

--- a/backend/tests/utils/dom-extractors/extractArtistSongs.test.ts
+++ b/backend/tests/utils/dom-extractors/extractArtistSongs.test.ts
@@ -1,101 +1,123 @@
 import { describe, it, expect } from "@jest/globals";
 import { extractArtistSongs } from "../../../utils/dom-extractors.js";
 import type { Song } from "../../../../shared/types/index.js";
-import { mockDocument, cleanupDOM } from "./shared-setup.js";
+import { cleanupDOM } from "./shared-setup.js";
 
 /**
  * Tests for extractArtistSongs function
- * Validates extraction of artist songs from DOM with deduplication and proper artist information
+ * Validates extraction of artist songs from DOM (ol > li > a[href] on
+ * /musicas.html) and the artist-name fallback chain: h2.t3 a -> page title
+ * (both "Artist - Cifra Club" and "Artist | Todas as músicas" formats) -> URL slug.
  */
+
+interface MockLink {
+  href: string;
+  primaryLabel?: string;
+}
+
+function mockLink({ href, primaryLabel }: MockLink) {
+  return {
+    getAttribute: (name: string) => (name === "href" ? href : null),
+    querySelector: (selector: string) =>
+      primaryLabel && selector === "p[class*='primaryLabel']"
+        ? { textContent: primaryLabel }
+        : null,
+  };
+}
+
+function setupDOM(links: ReturnType<typeof mockLink>[], { artistElement = null as { textContent: string } | null, title = "", pathname = "/oasis/" } = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).document = {
+    querySelectorAll: (selector: string) => (selector === "ol li a[href]" ? links : []),
+    querySelector: (selector: string) => (selector === "h2.t3 a" ? artistElement : null),
+    title,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).window = {
+    location: {
+      origin: "https://www.cifraclub.com.br",
+      pathname,
+    },
+  };
+}
 
 describe("extractArtistSongs", () => {
   cleanupDOM();
 
-  it("should extract artist songs and deduplicate with artist information", () => {
-    const mockLinks = [
-      {
-        textContent: "  Wonderwall  ",
-        href: "https://www.cifraclub.com.br/oasis/wonderwall/",
-      },
-      {
-        textContent: "Don't Look Back in Anger",
-        href: "https://www.cifraclub.com.br/oasis/dont-look-back-in-anger/",
-      },
-      {
-        textContent: "  Wonderwall  ", // Duplicate
-        href: "https://www.cifraclub.com.br/oasis/wonderwall/",
-      },
-    ];
-
-    mockDocument((selector: string) => {
-      if (selector === "a.art_music-link") {
-        return mockLinks;
-      }
-      return [];
-    }, "Oasis - Cifra Club");
+  it("extracts songs with title from the primaryLabel element and artist from h2.t3 a", () => {
+    setupDOM(
+      [
+        mockLink({ href: "/oasis/wonderwall/", primaryLabel: "Wonderwall" }),
+        mockLink({ href: "/oasis/dont-look-back-in-anger/", primaryLabel: "Don't Look Back in Anger" }),
+      ],
+      { artistElement: { textContent: "  Oasis  " } }
+    );
 
     const results: Song[] = extractArtistSongs();
 
     expect(results).toEqual([
       { title: "Wonderwall", path: "oasis/wonderwall", artist: "Oasis" },
-      {
-        title: "Don't Look Back in Anger",
-        path: "oasis/dont-look-back-in-anger",
-        artist: "Oasis",
-      },
+      { title: "Don't Look Back in Anger", path: "oasis/dont-look-back-in-anger", artist: "Oasis" },
     ]);
   });
 
-  it("should handle songs with multiple spaces in title", () => {
-    const mockLinks = [
-      {
-        textContent: "Don't   Look    Back   in   Anger",
-        href: "https://www.cifraclub.com.br/oasis/dont-look-back-in-anger/",
-      },
-    ];
-
-    mockDocument((selector: string) => {
-      if (selector === "a.art_music-link") {
-        return mockLinks;
-      }
-      return [];
-    }, "Oasis - Cifra Club");
+  it("falls back to a slug-derived title when the primaryLabel element is missing", () => {
+    setupDOM(
+      [mockLink({ href: "/oasis/dont-look-back-in-anger/" })],
+      { artistElement: { textContent: "Oasis" } }
+    );
 
     const results: Song[] = extractArtistSongs();
 
     expect(results).toEqual([
-      {
-        title: "Don't Look Back in Anger",
-        path: "oasis/dont-look-back-in-anger",
-        artist: "Oasis",
-      },
+      { title: "Dont Look Back In Anger", path: "oasis/dont-look-back-in-anger", artist: "Oasis" },
     ]);
   });
 
-  it("should extract artist from URL pathname when title is not available", () => {
-    const mockLinks = [
-      {
-        textContent: "Song Title",
-        href: "https://www.cifraclub.com.br/ac-dc/song-title/",
-      },
-    ];
-
-    // Mock with no title, so it should fallback to URL extraction
-    mockDocument((selector: string) => {
-      if (selector === "a.art_music-link") {
-        return mockLinks;
-      }
-      return [];
-    }, "");
-
-    // Update the pathname for this test
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).window.location.pathname = "/ac-dc/";
+  it("skips entries whose path is not exactly two segments, is a /letra page, or ends in a numeric id", () => {
+    setupDOM(
+      [
+        mockLink({ href: "/oasis/", primaryLabel: "Just the artist page" }),
+        mockLink({ href: "/oasis/wonderwall/letra/", primaryLabel: "Wonderwall Lyrics" }),
+        mockLink({ href: "/oasis/12345/", primaryLabel: "Numeric id" }),
+        mockLink({ href: "/oasis/wonderwall/", primaryLabel: "Wonderwall" }),
+      ],
+      { artistElement: { textContent: "Oasis" } }
+    );
 
     const results: Song[] = extractArtistSongs();
 
-    expect(results).toEqual([
-      { title: "Song Title", path: "ac-dc/song-title", artist: "Ac Dc" },
-    ]);
+    expect(results).toEqual([{ title: "Wonderwall", path: "oasis/wonderwall", artist: "Oasis" }]);
+  });
+
+  it("falls back to page title in the 'Artist - Cifra Club' format when h2.t3 a is absent", () => {
+    setupDOM([mockLink({ href: "/oasis/wonderwall/", primaryLabel: "Wonderwall" })], {
+      title: "Oasis - Cifra Club",
+    });
+
+    const results: Song[] = extractArtistSongs();
+
+    expect(results[0].artist).toBe("Oasis");
+  });
+
+  it("falls back to page title in the /musicas.html 'Artist | Todas as músicas' format when h2.t3 a is absent", () => {
+    setupDOM([mockLink({ href: "/ac-dc/back-in-black/", primaryLabel: "Back In Black" })], {
+      title: "AC/DC | Todas as músicas",
+    });
+
+    const results: Song[] = extractArtistSongs();
+
+    expect(results[0].artist).toBe("AC/DC");
+  });
+
+  it("falls back to a title-cased URL slug when neither h2.t3 a nor the page title match", () => {
+    setupDOM([mockLink({ href: "/ac-dc/back-in-black/", primaryLabel: "Back In Black" })], {
+      title: "",
+      pathname: "/ac-dc/",
+    });
+
+    const results: Song[] = extractArtistSongs();
+
+    expect(results[0].artist).toBe("Ac Dc");
   });
 });

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -99,13 +99,23 @@ export function extractSearchResults(): DOMSearchResult[] {
  * Extracts artist songs from CifraClub artist page DOM
  */
 export function extractArtistSongs(): Song[] {
-  // Extract artist name from page title (format: "Artist Name - Cifra Club")
+  // Extract artist name from the artist link element (h2.t3 a), which is always
+  // present on the artist page and already used elsewhere for this purpose (see
+  // extractChordSheetMeta below and cifraclub-song.ts). More reliable than the
+  // page title, whose format varies between song pages ("Artist - Cifra Club")
+  // and the /musicas.html listing page ("Artist | Todas as músicas").
   let artistName = "Unknown Artist";
-  const pageTitle = document.title;
-  if (pageTitle) {
-    const titleMatch = pageTitle.match(/^(.+?)\s*-\s*Cifra Club$/);
-    if (titleMatch) {
-      artistName = titleMatch[1].trim();
+  const artistElement = document.querySelector("h2.t3 a");
+  if (artistElement) {
+    artistName = artistElement.textContent?.trim() || "Unknown Artist";
+  }
+  if (artistName === "Unknown Artist") {
+    const pageTitle = document.title;
+    if (pageTitle) {
+      const titleMatch = pageTitle.match(/^(.+?)\s*(?:\||-)\s*(?:Todas as m|Cifra Club)/i);
+      if (titleMatch) {
+        artistName = titleMatch[1].trim();
+      }
     }
   }
   if (artistName === "Unknown Artist") {

--- a/frontend/api/artist-songs.ts
+++ b/frontend/api/artist-songs.ts
@@ -36,9 +36,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     const songs = await page.evaluate((artistSlug: string) => {
+      // Extract artist name from the artist link element (h2.t3 a), which is
+      // always present on the artist page. More reliable than the page title,
+      // whose format varies between song pages ("Artist - Cifra Club") and the
+      // /musicas.html listing page ("Artist | Todas as músicas").
       let artistName = "Unknown Artist";
-      const titleMatch = document.title.match(/^(.+?)\s*\|\s/);
-      if (titleMatch) artistName = titleMatch[1].trim();
+      const artistElement = document.querySelector("h2.t3 a");
+      if (artistElement) {
+        artistName = artistElement.textContent?.trim() || "Unknown Artist";
+      }
+      if (artistName === "Unknown Artist") {
+        const titleMatch = document.title.match(/^(.+?)\s*(?:\||-)\s*(?:Todas as m|Cifra Club)/i);
+        if (titleMatch) artistName = titleMatch[1].trim();
+      }
 
       const results: { title: string; artist: string; path: string }[] = [];
       document.querySelectorAll("ol li a[href]").forEach((link) => {

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/card";
 import { RefObject, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArtist";
+import { storeArtistDisplayName } from "@/search/utils/artist/artist-display-name-cache";
 import type { Song } from "../types/song";
 import type { ChordSheet, SongMetadata } from "@/types/chordSheet";
 import { useLazyChordSheet } from "@/storage/hooks/use-lazy-chord-sheet";
@@ -185,6 +186,10 @@ const SongViewer = ({
         JSON.stringify({ path: artistSlug, displayName: artist })
       );
     } catch {}
+    // Persist the displayName the song page is already showing, so /:artist
+    // can reuse it later instead of re-deriving a name from DOM scraping or a
+    // slug guess.
+    void storeArtistDisplayName(artistSlug, artist);
     navigate(`/${artistSlug}`);
   }, [artist, navigate, songObj.path]);
 

--- a/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
+++ b/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import ResultsList from "@/components/ui/ResultsList";
 import SearchResultsSection from "../SearchResultsSection/SearchResultsSection";
 import type { SearchResult, SearchResultsLayoutProps } from "./SearchResultsLayout.types";
+import { isSlugDerivedName } from "@/utils/url-slug-utils";
 import { ResultCard } from "../../ResultCard";
 import {
   Select,
@@ -46,9 +47,14 @@ const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
 
   const getSectionTitle = (): string => {
     if (activeArtist && results.length > 0 && results[0].type === "song") {
-      // Prefer the artist name carried on the song result (e.g. "AC/DC") over
-      // activeArtist.displayName, which can be slug-derived (e.g. "Ac Dc") when
-      // the page was restored from a route rather than a picked search result.
+      // Prefer activeArtist.displayName unless it's an untouched slug guess
+      // (e.g. "Ac Dc" for path "ac-dc") - in that case the scraped song's real
+      // artist name (e.g. "AC/DC") is more trustworthy. A confirmed
+      // displayName (from the search API, cache, or sessionStorage) always
+      // wins, since it can't be recovered from a per-song scrape.
+      if (activeArtist.displayName && !isSlugDerivedName(activeArtist.displayName, activeArtist.path)) {
+        return activeArtist.displayName;
+      }
       return results[0].artist || activeArtist.displayName;
     }
     switch (searchType) {

--- a/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
+++ b/frontend/src/search/components/SearchResults/SearchResultsLayout/SearchResultsLayout.tsx
@@ -46,7 +46,10 @@ const SearchResultsLayout: React.FC<SearchResultsLayoutProps> = ({
 
   const getSectionTitle = (): string => {
     if (activeArtist && results.length > 0 && results[0].type === "song") {
-      return activeArtist.displayName;
+      // Prefer the artist name carried on the song result (e.g. "AC/DC") over
+      // activeArtist.displayName, which can be slug-derived (e.g. "Ac Dc") when
+      // the page was restored from a route rather than a picked search result.
+      return results[0].artist || activeArtist.displayName;
     }
     switch (searchType) {
       case "artist":

--- a/frontend/src/search/components/SearchResults/hooks/__tests__/useSearchResultsViewModel.test.ts
+++ b/frontend/src/search/components/SearchResults/hooks/__tests__/useSearchResultsViewModel.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useSearchResultsViewModel } from "../useSearchResultsViewModel";
+import type { Song } from "@chordium/types";
+
+const baseParams = {
+  isDefault: true,
+  searchType: "artist" as const,
+  artists: [],
+  songs: [],
+  filterArtist: "",
+  filterSong: "",
+  handleView: vi.fn(),
+  handleArtistSelect: vi.fn(),
+};
+
+const song = (artist: string): Song => ({
+  title: "Sublime",
+  path: "florianopolis-house-of-prayer/sublime",
+  artist,
+});
+
+describe("useSearchResultsViewModel", () => {
+  it("prefers a confirmed activeArtist.displayName over the song's scraped artist", () => {
+    const { result } = renderHook(() =>
+      useSearchResultsViewModel({
+        ...baseParams,
+        activeArtist: { displayName: "Florianópolis House Of Prayer (fhop music)", path: "florianopolis-house-of-prayer", songCount: 156 },
+        artistSongs: [song("Florianopolis House Of Prayer")],
+      })
+    );
+
+    expect(result.current.results[0]).toMatchObject({ artist: "Florianópolis House Of Prayer (fhop music)" });
+  });
+
+  it("falls back to the song's scraped artist when activeArtist.displayName is just the slug guess", () => {
+    const { result } = renderHook(() =>
+      useSearchResultsViewModel({
+        ...baseParams,
+        activeArtist: { displayName: "ac dc", path: "ac-dc", songCount: 237 },
+        artistSongs: [song("AC/DC")],
+      })
+    );
+
+    expect(result.current.results[0]).toMatchObject({ artist: "AC/DC" });
+  });
+
+  it("falls back to the slug-derived name when neither a confirmed displayName nor a scraped artist is available", () => {
+    const { result } = renderHook(() =>
+      useSearchResultsViewModel({
+        ...baseParams,
+        activeArtist: { displayName: "ac dc", path: "ac-dc", songCount: 237 },
+        artistSongs: [song("")],
+      })
+    );
+
+    expect(result.current.results[0]).toMatchObject({ artist: "ac dc" });
+  });
+});

--- a/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
+++ b/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
@@ -56,7 +56,10 @@ export function useSearchResultsViewModel({
 
     if (searchType === 'artist') {
       if (activeArtist && artistSongs) {
-        const results = mapSongsToSearchResults(filteredArtistSongs.map(s => ({ ...s, artist: activeArtist?.displayName ?? s.artist })));
+        // Prefer the artist name scraped with each song (e.g. "AC/DC") over
+        // activeArtist.displayName, which can be slug-derived (e.g. "Ac Dc")
+        // when the page was restored from a route rather than a picked result.
+        const results = mapSongsToSearchResults(filteredArtistSongs.map(s => ({ ...s, artist: s.artist || activeArtist?.displayName })));
         return {
           results,
           onResultClick: (item: SearchResult) => {

--- a/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
+++ b/frontend/src/search/components/SearchResults/hooks/useSearchResultsViewModel.ts
@@ -3,6 +3,7 @@ import { usePropertyFilter } from '@/hooks/usePropertyFilter';
 import { mapArtistsToSearchResults, mapSongsToSearchResults } from '@/search/utils/mappers/search-mappers';
 import { filterSongsByArtistAndTitle } from '@/search/utils/filtering/filterSongsByArtistAndTitle';
 import { normalizeForSearch } from '@/search/utils/normalization/normalizeForSearch';
+import { isSlugDerivedName } from '@/utils/url-slug-utils';
 import type { Artist, Song, SearchType } from '@chordium/types';
 import type { SearchResult } from '../SearchResultsLayout/SearchResultsLayout.types';
 
@@ -56,10 +57,16 @@ export function useSearchResultsViewModel({
 
     if (searchType === 'artist') {
       if (activeArtist && artistSongs) {
-        // Prefer the artist name scraped with each song (e.g. "AC/DC") over
-        // activeArtist.displayName, which can be slug-derived (e.g. "Ac Dc")
-        // when the page was restored from a route rather than a picked result.
-        const results = mapSongsToSearchResults(filteredArtistSongs.map(s => ({ ...s, artist: s.artist || activeArtist?.displayName })));
+        // Prefer activeArtist.displayName unless it's an untouched slug guess
+        // (e.g. "Ac Dc" for path "ac-dc") - in that case a scraped song's real
+        // artist name (e.g. "AC/DC") is more trustworthy. A confirmed
+        // displayName (from the search API, cache, or sessionStorage) always
+        // wins, since it can't be recovered from a per-song scrape.
+        const trustedArtistName =
+          activeArtist.displayName && !isSlugDerivedName(activeArtist.displayName, activeArtist.path)
+            ? activeArtist.displayName
+            : undefined;
+        const results = mapSongsToSearchResults(filteredArtistSongs.map(s => ({ ...s, artist: trustedArtistName || s.artist || activeArtist?.displayName })));
         return {
           results,
           onResultClick: (item: SearchResult) => {

--- a/frontend/src/search/components/SearchTab/hooks/__tests__/useInitSearchStateEffect.test.ts
+++ b/frontend/src/search/components/SearchTab/hooks/__tests__/useInitSearchStateEffect.test.ts
@@ -96,6 +96,74 @@ describe("useInitSearchStateEffect", () => {
     consoleSpy.mockRestore();
   });
 
+  it('should prefer the stored artist displayName over the slug-derived name', () => {
+    const mockOptionsWithArtistPage = {
+      ...mockOptions,
+      location: { search: "", pathname: "/ac-dc" },
+      isOnArtistPage: vi.fn(() => true),
+      getCurrentArtistPath: vi.fn(() => "ac-dc"),
+    };
+
+    mockSessionStorage.getItem.mockImplementation((key: string) => {
+      if (key === "chordium_artist_display_name") {
+        return JSON.stringify({ path: "ac-dc", displayName: "AC/DC" });
+      }
+      return null;
+    });
+
+    renderHook(() => useInitSearchStateEffect(mockOptionsWithArtistPage));
+
+    expect(mockOptionsWithArtistPage.setActiveArtist).toHaveBeenCalledWith({
+      displayName: "AC/DC",
+      path: "ac-dc",
+      songCount: null,
+    });
+  });
+
+  it('should not remove the stored displayName, so it survives repeated back-navigation', () => {
+    const mockOptionsWithArtistPage = {
+      ...mockOptions,
+      location: { search: "", pathname: "/ac-dc" },
+      isOnArtistPage: vi.fn(() => true),
+      getCurrentArtistPath: vi.fn(() => "ac-dc"),
+    };
+
+    mockSessionStorage.getItem.mockImplementation((key: string) => {
+      if (key === "chordium_artist_display_name") {
+        return JSON.stringify({ path: "ac-dc", displayName: "AC/DC" });
+      }
+      return null;
+    });
+
+    renderHook(() => useInitSearchStateEffect(mockOptionsWithArtistPage));
+
+    expect(mockSessionStorage.removeItem).not.toHaveBeenCalledWith("chordium_artist_display_name");
+  });
+
+  it('should ignore a stored displayName for a different artist path', () => {
+    const mockOptionsWithArtistPage = {
+      ...mockOptions,
+      location: { search: "", pathname: "/oasis" },
+      isOnArtistPage: vi.fn(() => true),
+      getCurrentArtistPath: vi.fn(() => "oasis"),
+    };
+
+    mockSessionStorage.getItem.mockImplementation((key: string) => {
+      if (key === "chordium_artist_display_name") {
+        return JSON.stringify({ path: "ac-dc", displayName: "AC/DC" });
+      }
+      return null;
+    });
+
+    renderHook(() => useInitSearchStateEffect(mockOptionsWithArtistPage));
+
+    expect(mockOptionsWithArtistPage.setActiveArtist).toHaveBeenCalledWith({
+      displayName: "oasis",
+      path: "oasis",
+      songCount: null,
+    });
+  });
+
   it('should handle URL parameter initialization for search route', () => {
     const mockOptionsWithSearchParams = {
       ...mockOptions,

--- a/frontend/src/search/components/SearchTab/hooks/__tests__/useInitSearchStateEffect.test.ts
+++ b/frontend/src/search/components/SearchTab/hooks/__tests__/useInitSearchStateEffect.test.ts
@@ -1,6 +1,14 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useInitSearchStateEffect } from "../useInitSearchStateEffect";
+
+vi.mock("@/search/utils/artist/artist-display-name-cache", () => ({
+  getStoredArtistDisplayName: vi.fn().mockResolvedValue(null),
+}));
+
+import { getStoredArtistDisplayName } from "@/search/utils/artist/artist-display-name-cache";
+
+const mockGetStoredArtistDisplayName = vi.mocked(getStoredArtistDisplayName);
 
 // Mock sessionStorage
 const mockSessionStorage = {
@@ -38,6 +46,7 @@ describe("useInitSearchStateEffect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessionStorage.getItem.mockReturnValue(null);
+    mockGetStoredArtistDisplayName.mockResolvedValue(null);
   });
 
   it('should initialize with default values when no session storage data exists', () => {
@@ -162,6 +171,59 @@ describe("useInitSearchStateEffect", () => {
       path: "oasis",
       songCount: null,
     });
+  });
+
+  it('should upgrade to the cached displayName once the async lookup resolves', async () => {
+    const mockOptionsWithArtistPage = {
+      ...mockOptions,
+      location: { search: "", pathname: "/florianopolis-house-of-prayer" },
+      isOnArtistPage: vi.fn(() => true),
+      getCurrentArtistPath: vi.fn(() => "florianopolis-house-of-prayer"),
+    };
+
+    mockGetStoredArtistDisplayName.mockResolvedValue("Florianópolis House Of Prayer (fhop music)");
+
+    renderHook(() => useInitSearchStateEffect(mockOptionsWithArtistPage));
+
+    // Synchronous slug-derived guess is set first, so there's no blank flash.
+    expect(mockOptionsWithArtistPage.setActiveArtist).toHaveBeenCalledWith({
+      displayName: "florianopolis house of prayer",
+      path: "florianopolis-house-of-prayer",
+      songCount: null,
+    });
+
+    await waitFor(() => {
+      expect(mockOptionsWithArtistPage.setActiveArtist).toHaveBeenCalledWith({
+        displayName: "Florianópolis House Of Prayer (fhop music)",
+        path: "florianopolis-house-of-prayer",
+        songCount: null,
+      });
+    });
+  });
+
+  it('should not re-set activeArtist when the cached lookup matches what is already shown', async () => {
+    const mockOptionsWithArtistPage = {
+      ...mockOptions,
+      location: { search: "", pathname: "/ac-dc" },
+      isOnArtistPage: vi.fn(() => true),
+      getCurrentArtistPath: vi.fn(() => "ac-dc"),
+    };
+
+    mockSessionStorage.getItem.mockImplementation((key: string) => {
+      if (key === "chordium_artist_display_name") {
+        return JSON.stringify({ path: "ac-dc", displayName: "AC/DC" });
+      }
+      return null;
+    });
+    mockGetStoredArtistDisplayName.mockResolvedValue("AC/DC");
+
+    renderHook(() => useInitSearchStateEffect(mockOptionsWithArtistPage));
+
+    await waitFor(() => {
+      expect(mockGetStoredArtistDisplayName).toHaveBeenCalledWith("ac-dc");
+    });
+
+    expect(mockOptionsWithArtistPage.setActiveArtist).toHaveBeenCalledTimes(1);
   });
 
   it('should handle URL parameter initialization for search route', () => {

--- a/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
+++ b/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
@@ -93,7 +93,10 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
       const artistPath = getCurrentArtistPath();
       
       if (artistPath) {
-        // Prefer stored displayName (set when navigating from artist selection) over fromSlug
+        // Prefer stored displayName (set when navigating from artist selection) over
+        // fromSlug. Kept (not removed) so it survives repeated back-navigation to
+        // this artist; it's keyed by path and overwritten when a different artist
+        // is selected, so it can't go stale for the wrong artist.
         let artistName = fromSlug(artistPath);
         try {
           const stored = sessionStorage.getItem(ARTIST_DISPLAY_NAME_KEY);
@@ -101,7 +104,6 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
             const { path: storedPath, displayName } = JSON.parse(stored);
             if (storedPath === artistPath && displayName) {
               artistName = displayName;
-              sessionStorage.removeItem(ARTIST_DISPLAY_NAME_KEY);
             }
           }
         } catch {}

--- a/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
+++ b/frontend/src/search/components/SearchTab/hooks/useInitSearchStateEffect.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { fromSlug } from "@/utils/url-slug-utils";
 import { ARTIST_DISPLAY_NAME_KEY } from "@/search/utils/navigation/navigateToArtist";
+import { getStoredArtistDisplayName } from "@/search/utils/artist/artist-display-name-cache";
 import type { Artist } from "@chordium/types";
 
 interface InitSearchStateOptions {
@@ -112,6 +113,22 @@ export function useInitSearchStateEffect(options: InitSearchStateOptions) {
           displayName: artistName,
           path: artistPath,
           songCount: null,
+        });
+
+        // The displayName exactly as returned by the search API (e.g.
+        // "Florianópolis House Of Prayer (fhop music)") is the most trustworthy
+        // source available, since it doesn't depend on the source page's DOM
+        // markup or a slug guess. It's looked up async (IndexedDB), so it can
+        // upgrade the name set above once it resolves, e.g. on a fresh tab
+        // where sessionStorage is empty but this artist was searched before.
+        getStoredArtistDisplayName(artistPath).then((cachedDisplayName) => {
+          if (cachedDisplayName && cachedDisplayName !== artistName) {
+            setActiveArtist({
+              displayName: cachedDisplayName,
+              path: artistPath,
+              songCount: null,
+            });
+          }
         });
         
         // Restore the original search query from session storage if present.

--- a/frontend/src/search/types/searchQuery.ts
+++ b/frontend/src/search/types/searchQuery.ts
@@ -4,6 +4,13 @@
 export interface SearchQuery {
   artist: string;
   song: string;
+  /**
+   * Artist display name exactly as returned by the search API (e.g.
+   * "Florianópolis House Of Prayer (fhop music)"). Only set on the
+   * artist-song searchCache entry so it can be looked up by artist path
+   * later, instead of re-deriving a name from DOM scraping or a slug guess.
+   */
+  displayName?: string;
 }
 
 /**

--- a/frontend/src/search/utils/artist/__tests__/artist-display-name-cache.test.ts
+++ b/frontend/src/search/utils/artist/__tests__/artist-display-name-cache.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/storage/services/search-cache/search-cache-service", () => ({
+  searchCacheService: {
+    get: vi.fn(),
+    storeResults: vi.fn(),
+  },
+}));
+
+import { searchCacheService } from "@/storage/services/search-cache/search-cache-service";
+import { getStoredArtistDisplayName, storeArtistDisplayName } from "../artist-display-name-cache";
+
+const mockGet = vi.mocked(searchCacheService.get);
+const mockStoreResults = vi.mocked(searchCacheService.storeResults);
+
+describe("artist-display-name-cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getStoredArtistDisplayName", () => {
+    it("returns the cached displayName when present", async () => {
+      mockGet.mockResolvedValue({
+        searchKey: "acdc||artistsong",
+        results: [],
+        search: {
+          query: { artist: "ac-dc", song: "", displayName: "AC/DC" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any);
+
+      const result = await getStoredArtistDisplayName("ac-dc");
+
+      expect(result).toBe("AC/DC");
+    });
+
+    it("returns null when no cache entry exists", async () => {
+      mockGet.mockResolvedValue(null);
+
+      const result = await getStoredArtistDisplayName("unknown-artist");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the cache entry has no displayName", async () => {
+      mockGet.mockResolvedValue({
+        searchKey: "oasis||artistsong",
+        results: [],
+        search: {
+          query: { artist: "oasis", song: "" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any);
+
+      const result = await getStoredArtistDisplayName("oasis");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null instead of throwing when the cache lookup fails", async () => {
+      mockGet.mockRejectedValue(new Error("IndexedDB unavailable"));
+
+      const result = await getStoredArtistDisplayName("ac-dc");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("storeArtistDisplayName", () => {
+    it("stores the displayName keyed by artist path with empty results when nothing was cached yet", async () => {
+      mockGet.mockResolvedValue(null);
+
+      await storeArtistDisplayName("florianopolis-house-of-prayer", "Florianópolis House Of Prayer (fhop music)");
+
+      expect(mockStoreResults).toHaveBeenCalledWith({
+        searchKey: expect.any(String),
+        results: [],
+        search: {
+          query: { artist: "florianopolis-house-of-prayer", song: "", displayName: "Florianópolis House Of Prayer (fhop music)" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+      });
+    });
+
+    it("preserves already-cached songs when updating just the displayName", async () => {
+      const existingSongs = [{ title: "Sublime", path: "florianopolis-house-of-prayer/sublime", artist: "Florianopolis House Of Prayer" }];
+      mockGet.mockResolvedValue({
+        searchKey: "florianopolishouseofprayer||artistsong",
+        results: existingSongs,
+        search: {
+          query: { artist: "florianopolis-house-of-prayer", song: "" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any);
+
+      await storeArtistDisplayName("florianopolis-house-of-prayer", "Florianópolis House Of Prayer (fhop music)");
+
+      expect(mockStoreResults).toHaveBeenCalledWith({
+        searchKey: expect.any(String),
+        results: existingSongs,
+        search: {
+          query: { artist: "florianopolis-house-of-prayer", song: "", displayName: "Florianópolis House Of Prayer (fhop music)" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+      });
+    });
+
+    it("does not throw when the underlying store call fails", async () => {
+      mockGet.mockResolvedValue(null);
+      mockStoreResults.mockRejectedValue(new Error("IndexedDB unavailable"));
+
+      await expect(storeArtistDisplayName("ac-dc", "AC/DC")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/search/utils/artist/__tests__/fetch-artist-songs.test.ts
+++ b/frontend/src/search/utils/artist/__tests__/fetch-artist-songs.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/storage/services/search-cache/search-cache-service", () => ({
+  searchCacheService: {
+    get: vi.fn(),
+    storeResults: vi.fn(),
+  },
+}));
+
+import { searchCacheService } from "@/storage/services/search-cache/search-cache-service";
+import { fetchArtistSongs } from "../fetch-artist-songs";
+
+const mockGet = vi.mocked(searchCacheService.get);
+const mockStoreResults = vi.mocked(searchCacheService.storeResults);
+
+const songs = [{ title: "Sublime", path: "florianopolis-house-of-prayer/sublime", artist: "" }];
+
+describe("fetchArtistSongs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => songs,
+    }) as any;
+  });
+
+  it("preserves a displayName written to the cache after the initial read but before the fetch resolves", async () => {
+    // First read (before the network call): nothing cached yet.
+    // Second read (right before the write): storeArtistDisplayName has since
+    // written the displayName - simulates the real race between
+    // navigateToArtist's storeArtistDisplayName call and this fetch.
+    mockGet
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        searchKey: "florianopolishouseofprayer||artistsong",
+        results: [],
+        search: {
+          query: { artist: "florianopolis-house-of-prayer", song: "", displayName: "Florianópolis House Of Prayer (fhop music)" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any);
+
+    await fetchArtistSongs("florianopolis-house-of-prayer");
+
+    expect(mockStoreResults).toHaveBeenCalledWith({
+      searchKey: expect.any(String),
+      results: songs,
+      search: {
+        query: { artist: "florianopolis-house-of-prayer", song: "", displayName: "Florianópolis House Of Prayer (fhop music)" },
+        searchType: "artist-song",
+        dataSource: "neon",
+      },
+    });
+  });
+
+  it("stores results with an undefined displayName when nothing was ever cached", async () => {
+    mockGet.mockResolvedValue(null);
+
+    await fetchArtistSongs("ac-dc");
+
+    expect(mockStoreResults).toHaveBeenCalledWith({
+      searchKey: expect.any(String),
+      results: songs,
+      search: {
+        query: { artist: "ac-dc", song: "", displayName: undefined },
+        searchType: "artist-song",
+        dataSource: "neon",
+      },
+    });
+  });
+
+  it("returns cached songs directly without re-fetching when a non-empty cache entry exists", async () => {
+    mockGet.mockResolvedValue({
+      searchKey: "acdc||artistsong",
+      results: songs,
+      search: {
+        query: { artist: "ac-dc", song: "", displayName: "AC/DC" },
+        searchType: "artist-song",
+        dataSource: "neon",
+      },
+      storage: { timestamp: 0, version: 1, expiresAt: 0 },
+    } as any);
+
+    const result = await fetchArtistSongs("ac-dc");
+
+    expect(result).toBe(songs);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches songs when the only cache entry is a displayName-only placeholder with empty results", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        searchKey: "acdc||artistsong",
+        results: [],
+        search: {
+          query: { artist: "ac-dc", song: "", displayName: "AC/DC" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any)
+      .mockResolvedValueOnce({
+        searchKey: "acdc||artistsong",
+        results: [],
+        search: {
+          query: { artist: "ac-dc", song: "", displayName: "AC/DC" },
+          searchType: "artist-song",
+          dataSource: "neon",
+        },
+        storage: { timestamp: 0, version: 1, expiresAt: 0 },
+      } as any);
+
+    const result = await fetchArtistSongs("ac-dc");
+
+    expect(global.fetch).toHaveBeenCalled();
+    expect(result).toEqual(songs);
+  });
+});

--- a/frontend/src/search/utils/artist/artist-display-name-cache.ts
+++ b/frontend/src/search/utils/artist/artist-display-name-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Persists the artist displayName exactly as returned by the search API
+ * (e.g. "Florianópolis House Of Prayer (fhop music)"), keyed by artist path,
+ * so it can be reused when landing on /:artist later instead of re-deriving
+ * a name from DOM scraping or a slug guess.
+ *
+ * Reuses the existing artist-song searchCache entry (see fetchArtistSongs)
+ * rather than a separate store, since that entry is already looked up by
+ * the same artist path.
+ */
+import { SEARCH_TYPES } from "@chordium/types";
+import { searchCacheService } from "@/storage/services/search-cache/search-cache-service";
+import { getNormalizedSearchCacheKey } from "@/search/utils/normalization/getNormalizedSearchCacheKey";
+
+export async function getStoredArtistDisplayName(artistPath: string): Promise<string | null> {
+  try {
+    const searchKey = getNormalizedSearchCacheKey(artistPath, "", SEARCH_TYPES.ARTIST_SONG);
+    const cached = await searchCacheService.get(searchKey);
+    return cached?.search.query.displayName ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function storeArtistDisplayName(artistPath: string, displayName: string): Promise<void> {
+  try {
+    const searchKey = getNormalizedSearchCacheKey(artistPath, "", SEARCH_TYPES.ARTIST_SONG);
+    const cached = await searchCacheService.get(searchKey);
+    await searchCacheService.storeResults({
+      searchKey,
+      results: cached?.results ?? [],
+      search: {
+        query: { artist: artistPath, song: "", displayName },
+        searchType: SEARCH_TYPES.ARTIST_SONG,
+        dataSource: cached?.search.dataSource ?? "neon",
+      },
+    });
+  } catch {
+    // Best-effort persistence; failure just means the caller falls back
+    // to scraped/slug-derived names on the next visit.
+  }
+}

--- a/frontend/src/search/utils/artist/fetch-artist-songs.ts
+++ b/frontend/src/search/utils/artist/fetch-artist-songs.ts
@@ -23,8 +23,12 @@ export async function fetchArtistSongs(artistPath: string): Promise<Song[]> {
   const cachedEntry = await searchCacheService.get(searchKey);
   if (
     cachedEntry &&
-    cachedEntry.search.searchType === SEARCH_TYPES.ARTIST_SONG
+    cachedEntry.search.searchType === SEARCH_TYPES.ARTIST_SONG &&
+    cachedEntry.results.length > 0
   ) {
+    // A displayName-only entry (written by storeArtistDisplayName before any
+    // songs were fetched) has empty results - fall through to fetch songs
+    // rather than treating it as "this artist has zero songs".
     return cachedEntry.results as Song[];
   }
 
@@ -41,11 +45,19 @@ export async function fetchArtistSongs(artistPath: string): Promise<Song[]> {
     const data: Song[] = await resp.json();
     // Only cache non-empty results
     if (data.length > 0) {
+      // Re-read the cache instead of reusing the entry fetched before the
+      // network call above: storeArtistDisplayName (fired when the artist was
+      // clicked) can write in the meantime, and using the stale read here
+      // would overwrite that displayName with undefined.
+      const latestEntry = await searchCacheService.get(searchKey);
       await searchCacheService.storeResults({
         searchKey,
         results: data,
         search: {
-          query: { artist: artistPath, song: "" },
+          // Preserve a displayName already cached by storeArtistDisplayName
+          // (e.g. from clicking this artist in search results) so fetching
+          // the song list doesn't clobber it.
+          query: { artist: artistPath, song: "", displayName: latestEntry?.search.query.displayName },
           searchType: SEARCH_TYPES.ARTIST_SONG,
           dataSource: "neon",
         },

--- a/frontend/src/search/utils/navigation/navigateToArtist.ts
+++ b/frontend/src/search/utils/navigation/navigateToArtist.ts
@@ -5,6 +5,7 @@
  * @param navigate - React Router navigate function for programmatic navigation
  */
 import type { Artist } from "@chordium/types";
+import { storeArtistDisplayName } from "../artist/artist-display-name-cache";
 
 export const ARTIST_DISPLAY_NAME_KEY = 'chordium_artist_display_name';
 
@@ -15,6 +16,10 @@ export function navigateToArtist(
   try {
     sessionStorage.setItem(ARTIST_DISPLAY_NAME_KEY, JSON.stringify({ path: artist.path, displayName: artist.displayName }));
   } catch {}
+  // Persist the displayName as returned by the search API (e.g. "AC/DC"),
+  // so /:artist can reuse it later instead of re-deriving a name from DOM
+  // scraping or a slug guess.
+  void storeArtistDisplayName(artist.path, artist.displayName);
   const artistPath = `/${artist.path}`;
   navigate(artistPath, { replace: true });
 }

--- a/frontend/src/utils/url-slug-utils.ts
+++ b/frontend/src/utils/url-slug-utils.ts
@@ -39,3 +39,13 @@ export function fromSlug(slug: string): string {
 export function slugsMatch(slug1: string, slug2: string): boolean {
   return toSlug(fromSlug(slug1)) === toSlug(fromSlug(slug2));
 }
+
+/**
+ * Checks whether a displayName is just the untouched slug-derived guess for a
+ * path (e.g. "Ac Dc" for "ac-dc"), rather than a name confirmed by the search
+ * API or a scrape. Used to decide whether a more specific source (a cached
+ * or scraped name) should override it.
+ */
+export function isSlugDerivedName(displayName: string, path: string): boolean {
+  return displayName === fromSlug(path);
+}


### PR DESCRIPTION
- Artist pages and song results now show the correctly cased artist name (e.g. \`AC/DC\`) instead of a title-cased slug (e.g. \`Ac Dc\`)
- The name now comes from the artist link element on the source page, which is always present, instead of parsing the page title (whose format differs between the song page and the artist listing page)
- Fixes a related issue where the correct name would revert to the slug-derived fallback after navigating back to the artist page a second time