### PR TITLE
fix: restore the lyrics translation toggle

### DIFF
--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -94,6 +94,8 @@ const ChordViewer = () => {
     if (!path) return;
     const fetchLyricsInBackground = async () => {
       try {
+        // getLyrics reports entries from an older extractor as absent, so this
+        // refetches them once and then leaves them alone.
         const cached = await getLyrics(path);
         if (cached) return;
         const response = await fetch(`/api/cifraclub-lyrics?url=${encodeURIComponent(path)}`);

--- a/frontend/src/storage/services/lyrics-storage.ts
+++ b/frontend/src/storage/services/lyrics-storage.ts
@@ -8,9 +8,19 @@ export interface StoredLyrics {
   translated?: string;
   timestamp: number;
   expiresAt: number;
+  /** Extractor version that produced this entry; see LYRICS_EXTRACTOR_VERSION. */
+  version?: number;
 }
 
 const LYRICS_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/**
+ * Bump when a fix changes what the extractor produces, so entries cached by the
+ * previous version are refetched instead of being served for the rest of their
+ * TTL. Version 2 reads the lines with their breaks intact, without which no
+ * translation was ever detected.
+ */
+export const LYRICS_EXTRACTOR_VERSION = 2;
 
 export async function storeLyrics(songPath: string, lyrics: ChordSheet['lyrics']): Promise<void> {
   try {
@@ -31,6 +41,7 @@ export async function storeLyrics(songPath: string, lyrics: ChordSheet['lyrics']
       translated: lyrics?.translated,
       timestamp: now,
       expiresAt: now + LYRICS_TTL,
+      version: LYRICS_EXTRACTOR_VERSION,
     };
 
     store.put(entry);
@@ -64,8 +75,9 @@ export async function getLyrics(songPath: string): Promise<ChordSheet['lyrics'] 
           return;
         }
 
-        if (result.expiresAt < Date.now()) {
-          // Entry expired, delete it and return null
+        if (result.expiresAt < Date.now() || (result.version ?? 1) < LYRICS_EXTRACTOR_VERSION) {
+          // Expired, or written by an older extractor: drop it and report the
+          // entry as absent so the caller refetches once.
           const deleteTx = db.transaction(STORES.SONG_LYRICS, 'readwrite');
           deleteTx.objectStore(STORES.SONG_LYRICS).delete(songPath);
           resolve(null);

--- a/packages/scraping/src/lyrics.ts
+++ b/packages/scraping/src/lyrics.ts
@@ -22,31 +22,58 @@ interface ExtractedLyrics {
  * are laid out across more than one container, and it removes the need to guess
  * at an alternating pattern.
  *
+ * Lines are grouped by the paragraph holding them, which is what separates one
+ * section of a song from the next, and the groups are rejoined with a blank
+ * line so that structure survives.
+ *
  * Print pages carry no translation and expose the lyrics in a <pre>, which is
  * the fallback when no tagged lines are present.
  */
 function extractLyrics(): ExtractedLyrics | null {
-  const pairs = Array.from(document.querySelectorAll("span[data-original]"));
-  if (pairs.length) {
-    const originals: string[] = [];
-    const translations: string[] = [];
+  const taggedLines = Array.from(document.querySelectorAll("span[data-original]"));
+  if (taggedLines.length) {
+    const originalSections: string[][] = [];
+    const translatedSections: string[][] = [];
+    let originalCount = 0;
+    let translatedCount = 0;
+    let currentParagraph: Element | null = null;
 
-    for (const originalSpan of pairs) {
+    for (const originalSpan of taggedLines) {
       const line = originalSpan.textContent?.trim();
       if (!line) continue;
-      originals.push(line);
+
+      const paragraph = originalSpan.closest("p");
+      if (paragraph !== currentParagraph) {
+        currentParagraph = paragraph;
+        originalSections.push([]);
+        translatedSections.push([]);
+      }
+
+      originalSections[originalSections.length - 1].push(line);
+      originalCount++;
+
       // The sibling carries the same line translated; absent on untranslated pages.
       const translatedSpan = originalSpan.parentElement?.querySelector("span[data-translation]");
       const translated = translatedSpan?.textContent?.trim();
-      if (translated) translations.push(translated);
+      if (translated) {
+        translatedSections[translatedSections.length - 1].push(translated);
+        translatedCount++;
+      }
     }
 
-    if (originals.length) {
+    const join = (sections: string[][]) =>
+      sections
+        .map((lines) => lines.join("\n"))
+        .filter((section) => section)
+        .join("\n\n");
+
+    const original = join(originalSections);
+    if (original) {
       return {
-        original: originals.join("\n"),
+        original,
         // Only offer a translation when every line has one, so a partially
         // translated page cannot silently drop verses.
-        translated: translations.length === originals.length ? translations.join("\n") : undefined,
+        translated: translatedCount === originalCount ? join(translatedSections) : undefined,
       };
     }
   }

--- a/packages/scraping/src/lyrics.ts
+++ b/packages/scraping/src/lyrics.ts
@@ -16,21 +16,36 @@ interface ExtractedLyrics {
 /**
  * Pulls lyrics out of a source page.
  *
- * The regular route tags every line with data-original and data-translation,
- * so both versions are read straight from those attributes. Doing it by
- * attribute rather than by reading the rendered text matters because the lines
- * are laid out across more than one container, and it removes the need to guess
- * at an alternating pattern.
+ * On the regular route everything lives inside a single container the source
+ * marks with data-chord-container, so the search is scoped to it rather than to
+ * the whole document. That matters because the page also carries unrelated
+ * paragraphs, such as the app store notice, which would otherwise be picked up
+ * as the lyrics. Scoping also means the number of wrappers the lines happen to
+ * be nested in does not matter.
  *
- * Lines are grouped by the paragraph holding them, which is what separates one
- * section of a song from the next, and the groups are rejoined with a blank
- * line so that structure survives.
+ * Within it, each line of a translated song is tagged with data-original and
+ * data-translation, so both versions are read straight from those tags instead
+ * of guessing at an alternating pattern. Songs without a translation carry
+ * their lines as plain paragraphs, which is the second case below.
  *
- * Print pages carry no translation and expose the lyrics in a <pre>, which is
- * the fallback when no tagged lines are present.
+ * Either way the lines are grouped by the paragraph holding them, which is what
+ * separates one section of a song from the next, and the groups are rejoined
+ * with a blank line so that structure survives.
+ *
+ * Print pages carry no translation and expose the lyrics in a <pre>.
  */
 function extractLyrics(): ExtractedLyrics | null {
-  const taggedLines = Array.from(document.querySelectorAll("span[data-original]"));
+  const container = document.querySelector("[data-chord-container]");
+
+  const join = (sections: string[][]) =>
+    sections
+      .map((lines) => lines.join("\n"))
+      .filter((section) => section)
+      .join("\n\n");
+
+  const taggedLines = container
+    ? Array.from(container.querySelectorAll("span[data-original]"))
+    : [];
   if (taggedLines.length) {
     const originalSections: string[][] = [];
     const translatedSections: string[][] = [];
@@ -61,12 +76,6 @@ function extractLyrics(): ExtractedLyrics | null {
       }
     }
 
-    const join = (sections: string[][]) =>
-      sections
-        .map((lines) => lines.join("\n"))
-        .filter((section) => section)
-        .join("\n\n");
-
     const original = join(originalSections);
     if (original) {
       return {
@@ -78,6 +87,17 @@ function extractLyrics(): ExtractedLyrics | null {
     }
   }
 
+  // Untranslated songs: the lines sit in the container as plain paragraphs.
+  if (container) {
+    const paragraphs = Array.from(container.querySelectorAll("p"))
+      .map((paragraph) => (paragraph as HTMLElement).innerText ?? paragraph.textContent ?? "")
+      .map((text) => text.split("\n").map((line) => line.trim()).filter((line) => line))
+      .filter((lines) => lines.length);
+    const fromParagraphs = join(paragraphs);
+    if (fromParagraphs) return { original: fromParagraphs };
+  }
+
+  // Print pages have no container and hold the whole song in a single <pre>.
   const pre = document.querySelector("pre");
   const text = (pre as HTMLElement | null)?.innerText?.trim();
   return text ? { original: text } : null;

--- a/packages/scraping/src/lyrics.ts
+++ b/packages/scraping/src/lyrics.ts
@@ -6,61 +6,54 @@ export interface LyricsResult {
 }
 
 /**
- * Pulls lyric text out of a source page. Print pages expose a <pre>; the
- * regular route renders paragraphs inside <article> under hashed class names,
- * so the paragraphs are joined rather than matched by selector.
- *
- * innerText is required over textContent: the lines are separated by <br>, and
- * textContent runs them together, which leaves the translation unsplittable.
+ * Lyric text plus its translation when the page carries one.
  */
-function extractLyrics(): string | null {
-  const pre = document.querySelector("pre");
-  if (pre) {
-    const text = (pre as HTMLElement).innerText?.trim();
-    if (text) return text;
-  }
-
-  const article = document.querySelector("article");
-  if (article) {
-    const paragraphs = Array.from(article.querySelectorAll("p"))
-      .map((p) => (p as HTMLElement).innerText?.trim())
-      .filter((t): t is string => !!t && t.length > 20);
-    if (paragraphs.length) return paragraphs.join("\n\n");
-  }
-
-  return null;
+interface ExtractedLyrics {
+  original: string;
+  translated?: string;
 }
 
 /**
- * The regular route interleaves each translated line with its original line.
- * Splitting on that alternation recovers both versions; an odd or unbalanced
- * block means there is no translation, so it is left untouched.
+ * Pulls lyrics out of a source page.
+ *
+ * The regular route tags every line with data-original and data-translation,
+ * so both versions are read straight from those attributes. Doing it by
+ * attribute rather than by reading the rendered text matters because the lines
+ * are laid out across more than one container, and it removes the need to guess
+ * at an alternating pattern.
+ *
+ * Print pages carry no translation and expose the lyrics in a <pre>, which is
+ * the fallback when no tagged lines are present.
  */
-function splitInterleavedTranslation(
-  text: string
-): { original: string; translated: string } | null {
-  const blocks = text.split(/\n{2,}/);
-  const originalBlocks: string[] = [];
-  const translatedBlocks: string[] = [];
+function extractLyrics(): ExtractedLyrics | null {
+  const pairs = Array.from(document.querySelectorAll("span[data-original]"));
+  if (pairs.length) {
+    const originals: string[] = [];
+    const translations: string[] = [];
 
-  for (const block of blocks) {
-    const lines = block.split("\n").filter((l) => l.trim());
-    if (lines.length < 2 || lines.length % 2 !== 0) return null;
-    const translated: string[] = [];
-    const original: string[] = [];
-    for (let i = 0; i < lines.length; i += 2) {
-      translated.push(lines[i]);
-      original.push(lines[i + 1]);
+    for (const originalSpan of pairs) {
+      const line = originalSpan.textContent?.trim();
+      if (!line) continue;
+      originals.push(line);
+      // The sibling carries the same line translated; absent on untranslated pages.
+      const translatedSpan = originalSpan.parentElement?.querySelector("span[data-translation]");
+      const translated = translatedSpan?.textContent?.trim();
+      if (translated) translations.push(translated);
     }
-    translatedBlocks.push(translated.join("\n"));
-    originalBlocks.push(original.join("\n"));
+
+    if (originals.length) {
+      return {
+        original: originals.join("\n"),
+        // Only offer a translation when every line has one, so a partially
+        // translated page cannot silently drop verses.
+        translated: translations.length === originals.length ? translations.join("\n") : undefined,
+      };
+    }
   }
 
-  if (!originalBlocks.length) return null;
-  return {
-    original: originalBlocks.join("\n\n"),
-    translated: translatedBlocks.join("\n\n"),
-  };
+  const pre = document.querySelector("pre");
+  const text = (pre as HTMLElement | null)?.innerText?.trim();
+  return text ? { original: text } : null;
 }
 
 /**
@@ -74,7 +67,7 @@ async function tryLoadLyrics(
   url: string,
   timeout: number,
   logger?: (msg: string) => void
-): Promise<string | null> {
+): Promise<ExtractedLyrics | null> {
   try {
     page.setDefaultNavigationTimeout?.(timeout);
     // Print pages ship a pagination script that deletes overflow content from
@@ -87,12 +80,12 @@ async function tryLoadLyrics(
       return null;
     }
 
-    const text = await page.evaluate(extractLyrics);
-    if (!text?.trim()) {
+    const result = await page.evaluate(extractLyrics);
+    if (!result?.original?.trim()) {
       logger?.(`${url} yielded no lyrics`);
       return null;
     }
-    return text;
+    return result;
   } catch (error) {
     logger?.(`lyrics load failed for ${url}: ${error instanceof Error ? error.message : String(error)}`);
     return null;
@@ -111,29 +104,21 @@ export async function fetchLyrics(
   logger?: (msg: string) => void
 ): Promise<LyricsResult> {
   const base = baseUrl.replace(/\/+$/, "");
-  const result: LyricsResult = {};
 
+  // The regular route is tried first because it is the only one carrying the
+  // translation; the print page is a lighter fallback for the original alone.
   const routes = [
+    { url: `${base}/letra/`, timeout: 15000 },
     { url: `${base}/letra/imprimir.html`, timeout: 8000 },
-    { url: `${base}/letra/?translation=off`, timeout: 10000 },
   ];
 
+  const result: LyricsResult = {};
   for (const route of routes) {
-    const text = await tryLoadLyrics(page, route.url, route.timeout, logger);
-    if (text) {
-      result.original = text;
+    const found = await tryLoadLyrics(page, route.url, route.timeout, logger);
+    if (found) {
+      result.original = found.original;
+      if (found.translated) result.translated = found.translated;
       break;
-    }
-  }
-
-  const combined = await tryLoadLyrics(page, `${base}/letra/`, 15000, logger);
-  if (combined) {
-    const split = splitInterleavedTranslation(combined);
-    if (split) {
-      result.translated = split.translated;
-      if (!result.original) result.original = split.original;
-    } else if (!result.original) {
-      result.original = combined;
     }
   }
 

--- a/packages/scraping/src/lyrics.ts
+++ b/packages/scraping/src/lyrics.ts
@@ -9,18 +9,21 @@ export interface LyricsResult {
  * Pulls lyric text out of a source page. Print pages expose a <pre>; the
  * regular route renders paragraphs inside <article> under hashed class names,
  * so the paragraphs are joined rather than matched by selector.
+ *
+ * innerText is required over textContent: the lines are separated by <br>, and
+ * textContent runs them together, which leaves the translation unsplittable.
  */
 function extractLyrics(): string | null {
   const pre = document.querySelector("pre");
   if (pre) {
-    const text = (pre as HTMLElement).textContent?.trim();
+    const text = (pre as HTMLElement).innerText?.trim();
     if (text) return text;
   }
 
   const article = document.querySelector("article");
   if (article) {
     const paragraphs = Array.from(article.querySelectorAll("p"))
-      .map((p) => (p as HTMLElement).textContent?.trim())
+      .map((p) => (p as HTMLElement).innerText?.trim())
       .filter((t): t is string => !!t && t.length > 20);
     if (paragraphs.length) return paragraphs.join("\n\n");
   }

--- a/packages/scraping/src/lyrics.ts
+++ b/packages/scraping/src/lyrics.ts
@@ -32,10 +32,12 @@ interface ExtractedLyrics {
  * separates one section of a song from the next, and the groups are rejoined
  * with a blank line so that structure survives.
  *
- * Print pages carry no translation and expose the lyrics in a <pre>.
+ * Without that container there is nothing to read, so extraction stops rather
+ * than searching the page at large and mistaking interface text for lyrics.
  */
 function extractLyrics(): ExtractedLyrics | null {
   const container = document.querySelector("[data-chord-container]");
+  if (!container) return null;
 
   const join = (sections: string[][]) =>
     sections
@@ -43,9 +45,7 @@ function extractLyrics(): ExtractedLyrics | null {
       .filter((section) => section)
       .join("\n\n");
 
-  const taggedLines = container
-    ? Array.from(container.querySelectorAll("span[data-original]"))
-    : [];
+  const taggedLines = Array.from(container.querySelectorAll("span[data-original]"));
   if (taggedLines.length) {
     const originalSections: string[][] = [];
     const translatedSections: string[][] = [];
@@ -88,19 +88,14 @@ function extractLyrics(): ExtractedLyrics | null {
   }
 
   // Untranslated songs: the lines sit in the container as plain paragraphs.
-  if (container) {
-    const paragraphs = Array.from(container.querySelectorAll("p"))
-      .map((paragraph) => (paragraph as HTMLElement).innerText ?? paragraph.textContent ?? "")
-      .map((text) => text.split("\n").map((line) => line.trim()).filter((line) => line))
-      .filter((lines) => lines.length);
-    const fromParagraphs = join(paragraphs);
-    if (fromParagraphs) return { original: fromParagraphs };
-  }
+  const paragraphs = Array.from(container.querySelectorAll("p"))
+    .map((paragraph) => (paragraph as HTMLElement).innerText ?? paragraph.textContent ?? "")
+    .map((text) => text.split("\n").map((line) => line.trim()).filter((line) => line))
+    .filter((lines) => lines.length);
+  const fromParagraphs = join(paragraphs);
+  if (fromParagraphs) return { original: fromParagraphs };
 
-  // Print pages have no container and hold the whole song in a single <pre>.
-  const pre = document.querySelector("pre");
-  const text = (pre as HTMLElement | null)?.innerText?.trim();
-  return text ? { original: text } : null;
+  return null;
 }
 
 /**
@@ -117,8 +112,8 @@ async function tryLoadLyrics(
 ): Promise<ExtractedLyrics | null> {
   try {
     page.setDefaultNavigationTimeout?.(timeout);
-    // Print pages ship a pagination script that deletes overflow content from
-    // the DOM, which silently truncates the lyrics.
+    // The source ships a script that trims content out of the DOM, which
+    // silently truncates the lyrics.
     await page.setJavaScriptEnabled?.(false);
     await page.goto(url, { waitUntil: "domcontentloaded", timeout });
 
@@ -140,10 +135,9 @@ async function tryLoadLyrics(
 }
 
 /**
- * Fetches a song's lyrics, cascading: print page, then the no-translation
- * route. The regular route is always visited last because it is the only one
- * carrying the translation, and it doubles as the fallback for the original
- * when the earlier routes yield nothing.
+ * Fetches a song's lyrics from the route that carries them. Only this route
+ * wraps the song in the container the extraction relies on, and it is also the
+ * only one offering a translation, so there is nothing to cascade to.
  */
 export async function fetchLyrics(
   page: PageLike,
@@ -151,23 +145,11 @@ export async function fetchLyrics(
   logger?: (msg: string) => void
 ): Promise<LyricsResult> {
   const base = baseUrl.replace(/\/+$/, "");
+  const found = await tryLoadLyrics(page, `${base}/letra/`, 15000, logger);
+  if (!found) return {};
 
-  // The regular route is tried first because it is the only one carrying the
-  // translation; the print page is a lighter fallback for the original alone.
-  const routes = [
-    { url: `${base}/letra/`, timeout: 15000 },
-    { url: `${base}/letra/imprimir.html`, timeout: 8000 },
-  ];
-
-  const result: LyricsResult = {};
-  for (const route of routes) {
-    const found = await tryLoadLyrics(page, route.url, route.timeout, logger);
-    if (found) {
-      result.original = found.original;
-      if (found.translated) result.translated = found.translated;
-      break;
-    }
-  }
-
-  return result;
+  return {
+    original: found.original,
+    ...(found.translated ? { translated: found.translated } : {}),
+  };
 }


### PR DESCRIPTION
- Songs with a translation offer the switch between original and translated lyrics again; it was greyed out for every song because the translation went undetected
- The translation is no longer cut off partway through: both versions are now read from the per-line tags the source provides, so they stay aligned line for line and no verses are lost
- A translation is only offered when every line has one, so a partly translated page cannot quietly drop content
- Lyrics already cached without a translation are refetched once, so the switch appears without waiting out the 30 day cache or clearing site data
