### PR TITLE
fix: keep a saved song lyrics for as long as the song

### DIFF
--- a/frontend/src/storage/core/config/database.ts
+++ b/frontend/src/storage/core/config/database.ts
@@ -20,4 +20,4 @@ export const DB_NAME = "chordium-v1";
  * Increment this when making schema changes (adding/removing stores, indexes, etc.)
  * to trigger the onupgradeneeded event for migration.
  */
-export const DB_VERSION = 7;
+export const DB_VERSION = 8;

--- a/frontend/src/storage/services/lyrics-storage.ts
+++ b/frontend/src/storage/services/lyrics-storage.ts
@@ -7,18 +7,20 @@ export interface StoredLyrics {
   original?: string;
   translated?: string;
   timestamp: number;
-  expiresAt: number;
   /** Extractor version that produced this entry; see LYRICS_EXTRACTOR_VERSION. */
   version?: number;
 }
 
-const LYRICS_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
-
 /**
- * Bump when a fix changes what the extractor produces, so entries cached by the
- * previous version are refetched instead of being served for the rest of their
- * TTL. Version 2 reads the lines with their breaks intact, without which no
- * translation was ever detected.
+ * Lyrics carry no expiry of their own: like the full arrangement, they are
+ * content belonging to a song, and how long that song is kept is recorded once
+ * on its metadata. Saving a song therefore keeps its lyrics until it is
+ * deleted, and an unsaved song loses them when its metadata lapses.
+ *
+ * Bump when a fix changes what the extractor produces, so entries written by
+ * the previous version are refetched rather than served indefinitely. Version 2
+ * reads the lines with their breaks intact, without which no translation was
+ * ever detected.
  */
 export const LYRICS_EXTRACTOR_VERSION = 2;
 
@@ -34,13 +36,11 @@ export async function storeLyrics(songPath: string, lyrics: ChordSheet['lyrics']
     const tx = db.transaction(STORES.SONG_LYRICS, 'readwrite');
     const store = tx.objectStore(STORES.SONG_LYRICS);
 
-    const now = Date.now();
     const entry: StoredLyrics = {
       path: songPath,
       original: lyrics?.original,
       translated: lyrics?.translated,
-      timestamp: now,
-      expiresAt: now + LYRICS_TTL,
+      timestamp: Date.now(),
       version: LYRICS_EXTRACTOR_VERSION,
     };
 
@@ -75,9 +75,9 @@ export async function getLyrics(songPath: string): Promise<ChordSheet['lyrics'] 
           return;
         }
 
-        if (result.expiresAt < Date.now() || (result.version ?? 1) < LYRICS_EXTRACTOR_VERSION) {
-          // Expired, or written by an older extractor: drop it and report the
-          // entry as absent so the caller refetches once.
+        if ((result.version ?? 1) < LYRICS_EXTRACTOR_VERSION) {
+          // Written by an older extractor: drop it and report the entry as
+          // absent so the caller refetches once.
           const deleteTx = db.transaction(STORES.SONG_LYRICS, 'readwrite');
           deleteTx.objectStore(STORES.SONG_LYRICS).delete(songPath);
           resolve(null);

--- a/frontend/src/storage/stores/chord-sheets/database/connection/create-schema.ts
+++ b/frontend/src/storage/stores/chord-sheets/database/connection/create-schema.ts
@@ -56,8 +56,7 @@ export default function createSchema(db: IDBDatabase, version: number): void {
   // v7: Add lyrics storage for original + translated versions
   if (version === 7) {
     if (!db.objectStoreNames.contains(STORES.SONG_LYRICS)) {
-      const lyricsStore = db.createObjectStore(STORES.SONG_LYRICS, { keyPath: 'path' });
-      lyricsStore.createIndex('expiresAt', 'expiresAt', { unique: false });
+      db.createObjectStore(STORES.SONG_LYRICS, { keyPath: 'path' });
     }
   }
 }

--- a/frontend/src/storage/stores/chord-sheets/database/connection/migration-handler.ts
+++ b/frontend/src/storage/stores/chord-sheets/database/connection/migration-handler.ts
@@ -84,8 +84,14 @@ export function handleIndexedDBMigrations(
       }
       case 7: {
         // Migration to v7: add a store for song lyrics (original + translated),
-        // used by the lyrics view. Keyed by path, with a TTL index.
+        // used by the lyrics view. Keyed by path.
         createSchema(db, 7);
+        break;
+      }
+      case 8: {
+        // Migration to v8: lyrics no longer expire on their own, so the index
+        // and the field it pointed at are both removed.
+        dropLyricsExpiry(transaction);
         break;
       }
       // Add future migrations here
@@ -126,6 +132,30 @@ function dropUnsavedCachedContent(db: IDBDatabase, transaction?: IDBTransaction 
       fullStore?.delete(record.path);
       cursor.update({ ...record, storage: { ...record.storage, contentAvailable: false } });
     }
+    cursor.continue();
+  };
+}
+
+/**
+ * Removes every trace of the lyrics store's own expiry, left over from when
+ * lyrics expired independently of the song they belong to: the index, and the
+ * field it pointed at on records written before this version.
+ */
+function dropLyricsExpiry(transaction?: IDBTransaction | null): void {
+  if (!transaction) return;
+  if (!transaction.db.objectStoreNames.contains(STORES.SONG_LYRICS)) return;
+
+  const lyricsStore = transaction.objectStore(STORES.SONG_LYRICS);
+  if (lyricsStore.indexNames.contains('expiresAt')) {
+    lyricsStore.deleteIndex('expiresAt');
+  }
+
+  lyricsStore.openCursor().onsuccess = (event) => {
+    const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>).result;
+    if (!cursor) return;
+
+    const { expiresAt, ...record } = cursor.value as Record<string, unknown>;
+    if (expiresAt !== undefined) cursor.update(record);
     cursor.continue();
   };
 }

--- a/frontend/src/storage/stores/chord-sheets/operations/delete-chord-sheet.ts
+++ b/frontend/src/storage/stores/chord-sheets/operations/delete-chord-sheet.ts
@@ -2,20 +2,24 @@ import { executeWriteTransaction } from "../../../core/transactions";
 import { STORES } from "../../../core/config/stores";
 
 /**
- * Deletes a chord sheet entirely from cache:
- * - Removes metadata from songsMetadata
- * - Removes content from chordSheets
+ * Deletes a song and everything belonging to it: its metadata, both
+ * arrangements, and its lyrics. Every store is cleared even when the song never
+ * had that part, since deleting an absent key is a no-op, and skipping any of
+ * them would leave rows behind that nothing else collects.
  */
 export default async function deleteChordSheet(path: string): Promise<void> {
   if (!path) {
     throw new Error("Path is required for delete operation");
   }
 
-  await executeWriteTransaction(STORES.SONGS_METADATA, (store) => {
-    return store.delete(path);
-  });
+  const stores = [
+    STORES.SONGS_METADATA,
+    STORES.CHORD_SHEETS,
+    STORES.FULL_CHORD_SHEETS,
+    STORES.SONG_LYRICS,
+  ];
 
-  await executeWriteTransaction(STORES.CHORD_SHEETS, (store) => {
-    return store.delete(path);
-  });
+  for (const storeName of stores) {
+    await executeWriteTransaction(storeName, (store) => store.delete(path));
+  }
 }


### PR DESCRIPTION
- A saved song keeps its lyrics for as long as the song itself, instead of losing them after 30 days while its chords stayed; offline they were unrecoverable once gone
- Lyrics no longer carry an expiry of their own, matching the full arrangement: how long a song is kept is recorded once on its metadata and its content follows
- Deleting a song now removes its lyrics and full arrangement too, which were both left behind with nothing else collecting them
