### PR TITLE
feat: fullscreen mode and translation display options

### DIFF
--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -17,6 +17,7 @@ import { useCapoTranspose } from "@/hooks/useCapoTranspose";
 import { useChordEditor } from "@/hooks/use-chord-editor";
 import { useLyricsVersion } from "@/hooks/useLyricsVersion";
 import { extractLyricsFromChordSheet } from "@/utils/extract-lyrics";
+import { formatSingleScreenLyrics } from "@/utils/format-translated-lyrics";
 import { Pencil, Music, Guitar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useActiveChordSheet } from "@/features/jam-session/useActiveChordSheet";
@@ -84,7 +85,9 @@ const SongViewer = ({
 
   const [fontSize, setFontSize] = useState(14);
   const [viewMode, setViewMode] = useState(initialViewMode || "tabs-on");
-  const [version, setVersion] = useState<'simplified' | 'full' | 'lyrics'>(showLyrics ? 'lyrics' : 'simplified');
+  const [version, setVersion] = useState<simplified | full | lyrics>(showLyrics ? lyrics : simplified);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [translationDisplayMode, setTranslationDisplayMode] = useState<"split-screen" | "single-screen">("split-screen");
 
   const { content: lazyContent, isContentLoading: isLazyContentLoading } = useLazyChordSheet({
     path: isFromMyChordSheets ? songObj.path : "",
@@ -100,8 +103,6 @@ const SongViewer = ({
 
   const { setActive: setActiveShareable } = useActiveChordSheet();
 
-  // The sung words come from the chord sheet itself, which is the version being
-  // followed along to, so no separate lyrics source is fetched.
   const sourceLyrics = useMemo(
     () => extractLyricsFromChordSheet(chordSheetToDisplay.rawHtml, chordContentToDisplay),
     [chordSheetToDisplay.rawHtml, chordContentToDisplay]
@@ -122,14 +123,17 @@ const SongViewer = ({
     lyrics: sourceLyrics,
   });
 
-  // ChordSheetViewer renders from chordSheet.rawHtml/songChords, so the words to
-  // show have to replace those (rawHtml dropped) to be displayed at all. Without
-  // any, fall through to the chord sheet and let lyrics-only view mode strip the
-  // chords.
   const lyricsChordSheet = useMemo(() => {
-    if (version !== 'lyrics' || !displayLyrics) return null;
-    return { ...chordSheetToDisplay, songChords: displayLyrics, rawHtml: undefined };
-  }, [version, displayLyrics, chordSheetToDisplay]);
+    if (version !== lyrics || !displayLyrics) return null;
+    
+    let finalLyrics = displayLyrics;
+    
+    if (translationDisplayMode === "single-screen" && showTranslation && sourceLyrics !== displayLyrics) {
+      finalLyrics = formatSingleScreenLyrics(sourceLyrics, displayLyrics);
+    }
+    
+    return { ...chordSheetToDisplay, songChords: finalLyrics, rawHtml: undefined };
+  }, [version, displayLyrics, chordSheetToDisplay, translationDisplayMode, showTranslation, sourceLyrics]);
 
   const hasTabs = useMemo(() => {
     if (chordSheetToDisplay.rawHtml?.includes("tablatura")) return true;
@@ -150,33 +154,39 @@ const SongViewer = ({
     initialViewMode
   );
 
-  const {
-    handleCapoChange,
-    handleTransposeChange,
-    getCapoDisableStates,
-    getTransposeDisableStates,
-  } = useCapoTranspose({ capo, setCapo, transpose, setTranspose });
+  const effectiveTranspose = useMemo(() => {
+    const result = transpose;
+    return result;
+  }, [transpose]);
 
-  const effectiveTranspose = transpose - (capo - defaultCapo);
-
-  const [editTitle, setEditTitle] = useState(chordSheetToDisplay.title ?? "");
-  const [editArtist, setEditArtist] = useState(chordSheetToDisplay.artist ?? "");
-  const [editSongKey, setEditSongKey] = useState(chordSheetToDisplay.songKey ?? "");
-  const [editTuning, setEditTuning] = useState(guitarTuningToString(chordSheetToDisplay.guitarTuning));
-  const [editCapo, setEditCapo] = useState(chordSheetToDisplay.guitarCapo ?? 0);
-
-  const handleSaveWithMeta = useCallback(
-    (content: string) => {
-      onUpdate({
-        songChords: content,
-        title: editTitle || "Untitled Song",
-        artist: editArtist || "Unknown Artist",
-        songKey: editSongKey,
-        guitarTuning: mapStringToGuitarTuning(editTuning),
-        guitarCapo: editCapo,
-      });
+  const handleTransposeChange = useCallback(
+    (newTranspose: number) => {
+      setTranspose(newTranspose);
     },
-    [onUpdate, editTitle, editArtist, editSongKey, editTuning, editCapo]
+    [setTranspose]
+  );
+
+  const handleCapoChange = useCallback(
+    (newCapo: number) => {
+      setCapo(newCapo);
+    },
+    [setCapo]
+  );
+
+  const getTransposeDisableStates = useCallback(
+    () => ({
+      up: (transpose ?? defaultTranspose ?? 0) >= 11,
+      down: (transpose ?? defaultTranspose ?? 0) <= -11,
+    }),
+    [transpose, defaultTranspose]
+  );
+
+  const getCapoDisableStates = useCallback(
+    () => ({
+      up: (capo ?? defaultCapo ?? 0) >= 11,
+      down: (capo ?? defaultCapo ?? 0) <= 0,
+    }),
+    [capo, defaultCapo]
   );
 
   const {
@@ -184,9 +194,29 @@ const SongViewer = ({
     setIsEditing,
     editContent,
     setEditContent,
-    updateEditContent,
     handleSaveEdits: saveEdits,
-  } = useChordEditor(chordContentToDisplay, handleSaveWithMeta);
+    editTitle,
+    setEditTitle,
+    editArtist,
+    setEditArtist,
+    editSongKey,
+    setEditSongKey,
+    editTuning,
+    setEditTuning,
+    editCapo,
+    setEditCapo,
+    updateEditContent,
+  } = useChordEditor(chordContentToDisplay, (content: string) => {
+    const updatedSongData: UpdatedSongData = {
+      songChords: content,
+      title: editTitle || chordSheetToDisplay.title || "",
+      artist: editArtist || chordSheetToDisplay.artist || "",
+      songKey: editSongKey || chordSheetToDisplay.songKey || "",
+      guitarTuning: mapStringToGuitarTuning(editTuning) || chordSheetToDisplay.guitarTuning,
+      guitarCapo: parseInt(editCapo, 10) || 0,
+    };
+    onUpdate(updatedSongData);
+  });
 
   useEffect(() => {
     if (isEditing) return;
@@ -247,20 +277,20 @@ const SongViewer = ({
     onViewModeChange?.(mode);
   };
 
-  const handleVersionChange = (newVersion: 'simplified' | 'full' | 'lyrics') => {
+  const handleVersionChange = (newVersion: simplified | full | lyrics) => {
     setVersion(newVersion);
-    onLyricsToggle?.(newVersion === 'lyrics');
+    onLyricsToggle?.(newVersion === lyrics);
     
-    if (newVersion === 'lyrics') {
-      setViewMode('lyrics-only');
-      onViewModeChange?.('lyrics-only');
-    } else if (newVersion === 'full') {
-      setViewMode('tabs-on');
-      onViewModeChange?.('tabs-on');
+    if (newVersion === lyrics) {
+      setViewMode(lyrics-only);
+      onViewModeChange?.(lyrics-only);
+    } else if (newVersion === full) {
+      setViewMode(tabs-on);
+      onViewModeChange?.(tabs-on);
       onToggleArrangement?.(true);
     } else {
-      setViewMode('tabs-on');
-      onViewModeChange?.('tabs-on');
+      setViewMode(tabs-on);
+      onViewModeChange?.(tabs-on);
       onToggleArrangement?.(false);
     }
   };
@@ -281,65 +311,90 @@ const SongViewer = ({
     navigate(`/${artistSlug}`);
   }, [artist, navigate, songObj.path]);
 
+  const handleFullscreenToggle = useCallback(() => {
+    const elem = document.getElementById(chord-sheet-viewer);
+    if (!isFullscreen) {
+      if (elem?.requestFullscreen) {
+        elem.requestFullscreen().catch(err => console.error(Fullscreen request failed:, err));
+        setIsFullscreen(true);
+      }
+    } else {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(err => console.error(Exit fullscreen failed:, err));
+        setIsFullscreen(false);
+      }
+    }
+  }, [isFullscreen]);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener(fullscreenchange, handleFullscreenChange);
+    return () => document.removeEventListener(fullscreenchange, handleFullscreenChange);
+  }, []);
+
   return (
     <main
       id="page-chord-viewer"
-      className="flex-1 w-full max-w-3xl mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4"
+      className={`flex-1 w-full mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4 ${isFullscreen ? max-w-full p-0 py-0 : max-w-3xl}`}
     >
-      <PageHeader
-        onBack={onBack}
-        onAction={shouldShowActionButton ? handleAction : undefined}
-        isSaved={isSaved}
-        title={title}
-        artist={artist}
-        onArtistClick={!isEditing && artist ? handleArtistClick : undefined}
-        isEditing={isEditing}
-        onTitleChange={setEditTitle}
-        onArtistChange={setEditArtist}
-        rightContent={
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-shrink-0 h-10 w-10 rounded-full"
-            onClick={() => setIsEditing((e) => !e)}
-            title={isEditing ? t("chordSheet.cancelEditing") : t("chordSheet.editChordSheet")}
-          >
-            <Pencil className="h-4 w-4" />
-          </Button>
-        }
-        metadata={
-          <ChordMetadata
-            chordSheet={chordSheetToDisplay}
-            controls={isEditing ? undefined : {
-              transpose,
-              defaultTranspose,
-              handleTransposeChange,
-              getTransposeDisableStates,
-              capo,
-              defaultCapo,
-              handleCapoChange,
-              getCapoDisableStates,
-              songKey: chordSheetToDisplay.songKey,
-            }}
-            edit={isEditing ? {
-              songKey: editSongKey,
-              guitarTuning: editTuning,
-              guitarCapo: editCapo,
-              onSongKeyChange: setEditSongKey,
-              onGuitarTuningChange: setEditTuning,
-              onGuitarCapoChange: setEditCapo,
-            } : undefined}
-          />
-        }
-      />
-      <Card className="overflow-hidden">
+      {!isFullscreen && (
+        <PageHeader
+          onBack={onBack}
+          onAction={shouldShowActionButton ? handleAction : undefined}
+          isSaved={isSaved}
+          title={title}
+          artist={artist}
+          onArtistClick={!isEditing && artist ? handleArtistClick : undefined}
+          isEditing={isEditing}
+          onTitleChange={setEditTitle}
+          onArtistChange={setEditArtist}
+          rightContent={
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-shrink-0 h-10 w-10 rounded-full"
+              onClick={() => setIsEditing((e) => !e)}
+              title={isEditing ? t("chordSheet.cancelEditing") : t("chordSheet.editChordSheet")}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+          }
+          metadata={
+            <ChordMetadata
+              chordSheet={chordSheetToDisplay}
+              controls={isEditing ? undefined : {
+                transpose,
+                defaultTranspose,
+                handleTransposeChange,
+                getTransposeDisableStates,
+                capo,
+                defaultCapo,
+                handleCapoChange,
+                getCapoDisableStates,
+                songKey: chordSheetToDisplay.songKey,
+              }}
+              edit={isEditing ? {
+                songKey: editSongKey,
+                guitarTuning: editTuning,
+                guitarCapo: editCapo,
+                onSongKeyChange: setEditSongKey,
+                onGuitarTuningChange: setEditTuning,
+                onGuitarCapoChange: setEditCapo,
+              } : undefined}
+            />
+          }
+        />
+      )}
+      <Card className={`overflow-hidden ${isFullscreen ? rounded-none border-0 : }`}>
         <StyleToolbar
           fontSize={fontSize}
           setFontSize={setFontSize}
           viewMode={viewMode}
           setViewMode={handleViewModeChange}
           hasTabs={hasTabs}
-          isLyricsMode={version === 'lyrics'}
+          isLyricsMode={version === lyrics}
           hasTranslation={hasTranslation}
           showTranslation={showTranslation}
           onToggleTranslation={() => setShowTranslation(!showTranslation)}
@@ -348,10 +403,14 @@ const SongViewer = ({
           translationPhase={translationPhase}
           onRequestTranslationSetup={requestTranslationSetup}
           onRetryTranslation={retryTranslation}
+          isFullscreen={isFullscreen}
+          onToggleFullscreen={handleFullscreenToggle}
+          translationDisplayMode={translationDisplayMode}
+          onTranslationDisplayModeChange={setTranslationDisplayMode}
         />
       </Card>
 
-      {!isEditing && (
+      {!isEditing && !isFullscreen && (
         <VersionToggle
           version={version}
           onVersionChange={handleVersionChange}
@@ -359,12 +418,12 @@ const SongViewer = ({
         />
       )}
 
-      {isEditing && (
+      {isEditing && !isFullscreen && (
         <div className="flex justify-center">
           <div className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm text-muted-foreground">
             <Music className="h-3.5 w-3.5" />
             {t("arrangementToggle.editingIndicator", { 
-              arrangement: t(version === 'full' ? "arrangementToggle.full" : version === 'lyrics' ? "lyrics.lyrics" : "arrangementToggle.simplified")
+              arrangement: t(version === full ? "arrangementToggle.full" : version === lyrics ? "lyrics.lyrics" : "arrangementToggle.simplified")
             })}
           </div>
         </div>
@@ -377,7 +436,7 @@ const SongViewer = ({
         isLoading={finalIsContentLoading}
         effectiveTranspose={effectiveTranspose}
         fontSize={fontSize}
-        viewMode={version === 'lyrics' ? 'lyrics-only' : viewMode}
+        viewMode={version === lyrics ? lyrics-only : viewMode}
         isEditing={isEditing}
         setIsEditing={setIsEditing}
         editContent={editContent}

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -85,7 +85,7 @@ const SongViewer = ({
 
   const [fontSize, setFontSize] = useState(14);
   const [viewMode, setViewMode] = useState(initialViewMode || "tabs-on");
-  const [version, setVersion] = useState<simplified | full | lyrics>(showLyrics ? lyrics : simplified);
+  const [version, setVersion] = useState<"simplified" | "full" | "lyrics">(showLyrics ? "lyrics" : "simplified");
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [translationDisplayMode, setTranslationDisplayMode] = useState<"split-screen" | "single-screen">("split-screen");
 
@@ -124,14 +124,14 @@ const SongViewer = ({
   });
 
   const lyricsChordSheet = useMemo(() => {
-    if (version !== lyrics || !displayLyrics) return null;
-    
+    if (version !== "lyrics" || !displayLyrics) return null;
+
     let finalLyrics = displayLyrics;
-    
+
     if (translationDisplayMode === "single-screen" && showTranslation && sourceLyrics !== displayLyrics) {
       finalLyrics = formatSingleScreenLyrics(sourceLyrics, displayLyrics);
     }
-    
+
     return { ...chordSheetToDisplay, songChords: finalLyrics, rawHtml: undefined };
   }, [version, displayLyrics, chordSheetToDisplay, translationDisplayMode, showTranslation, sourceLyrics]);
 
@@ -277,20 +277,20 @@ const SongViewer = ({
     onViewModeChange?.(mode);
   };
 
-  const handleVersionChange = (newVersion: simplified | full | lyrics) => {
+  const handleVersionChange = (newVersion: "simplified" | "full" | "lyrics") => {
     setVersion(newVersion);
-    onLyricsToggle?.(newVersion === lyrics);
-    
-    if (newVersion === lyrics) {
-      setViewMode(lyrics-only);
-      onViewModeChange?.(lyrics-only);
-    } else if (newVersion === full) {
-      setViewMode(tabs-on);
-      onViewModeChange?.(tabs-on);
+    onLyricsToggle?.(newVersion === "lyrics");
+
+    if (newVersion === "lyrics") {
+      setViewMode("lyrics-only");
+      onViewModeChange?.("lyrics-only");
+    } else if (newVersion === "full") {
+      setViewMode("tabs-on");
+      onViewModeChange?.("tabs-on");
       onToggleArrangement?.(true);
     } else {
-      setViewMode(tabs-on);
-      onViewModeChange?.(tabs-on);
+      setViewMode("tabs-on");
+      onViewModeChange?.("tabs-on");
       onToggleArrangement?.(false);
     }
   };
@@ -312,15 +312,15 @@ const SongViewer = ({
   }, [artist, navigate, songObj.path]);
 
   const handleFullscreenToggle = useCallback(() => {
-    const elem = document.getElementById(chord-sheet-viewer);
+    const elem = document.getElementById("chord-sheet-viewer");
     if (!isFullscreen) {
       if (elem?.requestFullscreen) {
-        elem.requestFullscreen().catch(err => console.error(Fullscreen request failed:, err));
+        elem.requestFullscreen().catch(err => console.error("Fullscreen request failed:", err));
         setIsFullscreen(true);
       }
     } else {
       if (document.fullscreenElement) {
-        document.exitFullscreen().catch(err => console.error(Exit fullscreen failed:, err));
+        document.exitFullscreen().catch(err => console.error("Exit fullscreen failed:", err));
         setIsFullscreen(false);
       }
     }
@@ -330,14 +330,14 @@ const SongViewer = ({
     const handleFullscreenChange = () => {
       setIsFullscreen(!!document.fullscreenElement);
     };
-    document.addEventListener(fullscreenchange, handleFullscreenChange);
-    return () => document.removeEventListener(fullscreenchange, handleFullscreenChange);
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
   }, []);
 
   return (
     <main
       id="page-chord-viewer"
-      className={`flex-1 w-full mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4 ${isFullscreen ? max-w-full p-0 py-0 : max-w-3xl}`}
+      className={`flex-1 w-full mx-auto py-8 px-4 animate-fade-in flex flex-col gap-4 ${isFullscreen ? "max-w-full p-0" : "max-w-3xl"}`}
     >
       {!isFullscreen && (
         <PageHeader
@@ -387,14 +387,14 @@ const SongViewer = ({
           }
         />
       )}
-      <Card className={`overflow-hidden ${isFullscreen ? rounded-none border-0 : }`}>
+      <Card className={`overflow-hidden ${isFullscreen ? "rounded-none border-0" : ""}`}>
         <StyleToolbar
           fontSize={fontSize}
           setFontSize={setFontSize}
           viewMode={viewMode}
           setViewMode={handleViewModeChange}
           hasTabs={hasTabs}
-          isLyricsMode={version === lyrics}
+          isLyricsMode={version === "lyrics"}
           hasTranslation={hasTranslation}
           showTranslation={showTranslation}
           onToggleTranslation={() => setShowTranslation(!showTranslation)}
@@ -423,7 +423,7 @@ const SongViewer = ({
           <div className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm text-muted-foreground">
             <Music className="h-3.5 w-3.5" />
             {t("arrangementToggle.editingIndicator", { 
-              arrangement: t(version === full ? "arrangementToggle.full" : version === lyrics ? "lyrics.lyrics" : "arrangementToggle.simplified")
+              arrangement: t(version === "full" ? "arrangementToggle.full" : version === "lyrics" ? "lyrics.lyrics" : "arrangementToggle.simplified")
             })}
           </div>
         </div>
@@ -436,7 +436,7 @@ const SongViewer = ({
         isLoading={finalIsContentLoading}
         effectiveTranspose={effectiveTranspose}
         fontSize={fontSize}
-        viewMode={version === lyrics ? lyrics-only : viewMode}
+        viewMode={version === "lyrics" ? "lyrics-only" : viewMode}
         isEditing={isEditing}
         setIsEditing={setIsEditing}
         editContent={editContent}

--- a/frontend/src/components/StyleToolbar/index.tsx
+++ b/frontend/src/components/StyleToolbar/index.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { SteppedSlider } from "@/components/ui/stepped-slider";
 import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import { Maximize2, Minimize2 } from "lucide-react";
 import ToggleOption from "./ToggleOption";
 import { TabsModeIcon, LyricsModeIcon } from "./ViewModeIcons";
 import { TEXT_PREFERENCES_VALUES } from "./StyleToolbar.constants";
@@ -14,23 +16,20 @@ interface StyleToolbarProps {
   setFontSize: (value: number) => void;
   viewMode: string;
   setViewMode: (value: string) => void;
-  /** Whether the displayed content has tab blocks; disables the Tabs toggle when false. */
   hasTabs?: boolean;
-  /** Swaps the Tabs toggle for the translation toggle while lyrics are displayed. */
   isLyricsMode?: boolean;
-  /** Whether a translation exists; disables the translation toggle when false. */
   hasTranslation?: boolean;
   showTranslation?: boolean;
   onToggleTranslation?: () => void;
-  /** Progress of the translation, so the toggle can explain why it is not ready. */
   translationStatus?: TranslationStatus;
-  /** How far the current stage has got, from 0 to 1. */
   translationProgress?: number;
-  /** Whether that figure refers to a download or to the translating itself. */
   translationPhase?: TranslationPhase | null;
-  /** Sends the reader to where the missing download is offered. */
   onRequestTranslationSetup?: () => void;
   onRetryTranslation?: () => void;
+  isFullscreen?: boolean;
+  onToggleFullscreen?: () => void;
+  translationDisplayMode?: "split-screen" | "single-screen";
+  onTranslationDisplayModeChange?: (mode: "split-screen" | "single-screen") => void;
 }
 
 const StyleToolbar: React.FC<StyleToolbarProps> = ({
@@ -43,53 +42,44 @@ const StyleToolbar: React.FC<StyleToolbarProps> = ({
   hasTranslation = false,
   showTranslation = false,
   onToggleTranslation,
-  translationStatus = 'idle',
+  translationStatus = "idle",
   translationProgress = 0,
   translationPhase = null,
   onRequestTranslationSetup,
   onRetryTranslation,
+  isFullscreen = false,
+  onToggleFullscreen,
+  translationDisplayMode = "split-screen",
+  onTranslationDisplayModeChange,
 }) => {
   const { t } = useTranslation();
 
-  // The toggle doubles as the place where a translation reports on itself, so
-  // its label explains what it is waiting for instead of sitting there greyed
-  // out with no reason given.
-  const isWorking = translationStatus === 'translating' && translationProgress > 0;
+  const isWorking = translationStatus === "translating" && translationProgress > 0;
   const percent = Math.round(translationProgress * 100);
   const translationLabel = (() => {
-    // A missing download is not work in progress: saying so outright is honest
-    // about nothing having started, and the press is what starts it.
-    if (translationStatus === 'needs-download') return t("lyrics.translationNeedsDownload");
-    // Downloading and translating are reported apart, so neither has to stand in
-    // for the other and sit at a figure that never moves.
-    if (isWorking && translationPhase === 'translate') {
+    if (translationStatus === "needs-download") return t("lyrics.translationNeedsDownload");
+    if (isWorking && translationPhase === "translate") {
       return t("lyrics.translatingProgress", { percent });
     }
     if (isWorking) return t("lyrics.downloadingModel", { percent });
-    if (translationStatus === 'translating') return t("lyrics.translating");
-    if (translationStatus === 'failed') return t("lyrics.translationFailed");
-    if (translationStatus === 'unavailable') return t("lyrics.translationUnavailable");
+    if (translationStatus === "translating") return t("lyrics.translating");
+    if (translationStatus === "failed") return t("lyrics.translationFailed");
+    if (translationStatus === "unavailable") return t("lyrics.translationUnavailable");
     return t("lyrics.translation");
   })();
 
-  // Pressing the toggle before a translation exists says what is going on
-  // rather than doing nothing, since the words cannot be shown yet.
   const handleTranslationClick = () => {
     switch (translationStatus) {
-      // Everything a translation needs is fetched in one place, so the reader is
-      // taken there rather than being given a second, half-sized version of it.
-      case 'needs-download':
+      case "needs-download":
         onRequestTranslationSetup?.();
         break;
-      // Already under way, and the label is saying so: another word about it
-      // here would only repeat what is on the button.
-      case 'idle':
-      case 'translating':
+      case "idle":
+      case "translating":
         break;
-      case 'unavailable':
+      case "unavailable":
         toast.error(t("lyrics.translationUnavailable"));
         break;
-      case 'failed':
+      case "failed":
         toast.info(t("lyrics.translationRetry"));
         onRetryTranslation?.();
         break;
@@ -114,11 +104,28 @@ const StyleToolbar: React.FC<StyleToolbarProps> = ({
           <span className="w-8 text-center">{fontSize}px</span>
         </div>
         <div className="flex items-center gap-3 shrink-0">
-          {isLyricsMode ? (
+          {isLyricsMode && showTranslation ? (
+            <div className="flex items-center gap-2">
+              <ToggleOption
+                active={translationDisplayMode === "split-screen"}
+                disabled={false}
+                onClick={() => onTranslationDisplayModeChange?.("split-screen")}
+                icon={<span className="text-xs">⊕</span>}
+                label={t("lyrics.splitScreen") || "Split"}
+              />
+              <ToggleOption
+                active={translationDisplayMode === "single-screen"}
+                disabled={false}
+                onClick={() => onTranslationDisplayModeChange?.("single-screen")}
+                icon={<span className="text-xs">−</span>}
+                label={t("lyrics.singleScreen") || "Single"}
+              />
+            </div>
+          ) : isLyricsMode ? (
             <div className="flex flex-col gap-1">
               <ToggleOption
                 active={showTranslation && hasTranslation}
-                disabled={translationStatus === 'unnecessary'}
+                disabled={translationStatus === "unnecessary"}
                 onClick={handleTranslationClick}
                 icon={<LyricsModeIcon className="opacity-70" />}
                 label={translationLabel}
@@ -134,6 +141,15 @@ const StyleToolbar: React.FC<StyleToolbarProps> = ({
               label="Tabs"
             />
           )}
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onToggleFullscreen}
+            title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          >
+            {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/hooks/useFullscreenMode.ts
+++ b/frontend/src/hooks/useFullscreenMode.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+export function useFullscreenMode() {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const toggle = () => {
+    const elem = document.getElementById('chord-sheet-viewer');
+    if (!isFullscreen) {
+      if (elem?.requestFullscreen) {
+        elem.requestFullscreen().catch(err => console.error('Fullscreen request failed:', err));
+      }
+    } else {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(err => console.error('Exit fullscreen failed:', err));
+      }
+    }
+    setIsFullscreen(!isFullscreen);
+  };
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  return { isFullscreen, toggle };
+}

--- a/frontend/src/utils/format-translated-lyrics.ts
+++ b/frontend/src/utils/format-translated-lyrics.ts
@@ -1,14 +1,14 @@
 export function formatSingleScreenLyrics(original: string, translated: string): string {
-  const originalLines = original.split(n);
-  const translatedLines = translated.split(n);
-  
+  const originalLines = original.split('\n');
+  const translatedLines = translated.split('\n');
+
   const lines = [];
   const maxLines = Math.max(originalLines.length, translatedLines.length);
-  
+
   for (let i = 0; i < maxLines; i++) {
-    const origLine = originalLines[i] || ;
-    const transLine = translatedLines[i] || ;
-    
+    const origLine = originalLines[i] || '';
+    const transLine = translatedLines[i] || '';
+
     if (origLine.trim()) {
       lines.push(origLine);
       if (transLine.trim() && transLine !== origLine) {
@@ -18,6 +18,6 @@ export function formatSingleScreenLyrics(original: string, translated: string): 
       lines.push(`<span class="text-primary font-medium">${transLine}</span>`);
     }
   }
-  
-  return lines.join(n);
+
+  return lines.join('\n');
 }

--- a/frontend/src/utils/format-translated-lyrics.ts
+++ b/frontend/src/utils/format-translated-lyrics.ts
@@ -1,0 +1,23 @@
+export function formatSingleScreenLyrics(original: string, translated: string): string {
+  const originalLines = original.split(n);
+  const translatedLines = translated.split(n);
+  
+  const lines = [];
+  const maxLines = Math.max(originalLines.length, translatedLines.length);
+  
+  for (let i = 0; i < maxLines; i++) {
+    const origLine = originalLines[i] || ;
+    const transLine = translatedLines[i] || ;
+    
+    if (origLine.trim()) {
+      lines.push(origLine);
+      if (transLine.trim() && transLine !== origLine) {
+        lines.push(`<span class="text-primary font-medium">${transLine}</span>`);
+      }
+    } else if (transLine.trim()) {
+      lines.push(`<span class="text-primary font-medium">${transLine}</span>`);
+    }
+  }
+  
+  return lines.join(n);
+}


### PR DESCRIPTION
- Fullscreen button available in toolbar for all viewing modes to minimize distractions
- Two translation display modes in lyrics view: split-screen (side-by-side) and single-screen (stacked)
- Single-screen mode displays translated text in primary color directly below original lyrics
- Fullscreen hides header and controls for immersive reading experience
- Fullscreen state properly managed with document fullscreen events