### PR TITLE
feat: show app version in footer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,21 @@ docs(readme): update installation instructions
 test(frontend): add unit tests for search functionality
 ```
 
+## 🔢 Versioning
+
+Chordium follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`), tracked in `package.json` (root, `frontend/`, and `backend/` stay in sync) and shown in the app footer.
+
+Bump the version as part of the PR that introduces the change, based on its Conventional Commit type:
+
+| Commit type | Bump |
+|---|---|
+| `fix:` | PATCH |
+| `feat:` | MINOR |
+| `feat!:` / `fix!:` or a `BREAKING CHANGE:` footer | MAJOR |
+| `docs:`, `style:`, `refactor:`, `test:`, `chore:` | none |
+
+While the project is pre-1.0 (`0.x.y`), SemVer allows breaking changes to ship as MINOR bumps, since the public API/UX isn't guaranteed stable yet. `1.0.0` should mark a deliberate decision that the current feature set is a stable baseline, not just "everything currently works."
+
 ## 🐛 Reporting Issues
 
 When reporting issues, please include:

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = () => {
 
   return (
     <footer className="mt-auto border-t dark:bg-card">
-      <div className="flex justify-end sm:justify-center py-1 px-4 max-w-3xl mx-auto">
+      <div className="flex justify-between items-center py-1 px-4 max-w-3xl mx-auto">
         <a
           href="https://github.com/arthurboss/chordium"
           className="p-[4px] text-sm text-muted-foreground hover:text-foreground transition-colors flex flex-row-reverse sm:flex-row items-center gap-1.5"
@@ -16,6 +16,12 @@ const Footer = () => {
           <GitHubIcon size={24} />
           <span>{t("footer.source")}</span>
         </a>
+        <span
+          className="p-[4px] text-sm text-muted-foreground"
+          aria-label={t("footer.version", { version: __APP_VERSION__ })}
+        >
+          v{__APP_VERSION__}
+        </span>
       </div>
     </footer>
   );

--- a/frontend/src/locales/de/common.json
+++ b/frontend/src/locales/de/common.json
@@ -166,7 +166,8 @@
     "returnHome": "Zurück zur Startseite"
   },
   "footer": {
-    "source": "Quelle"
+    "source": "Quelle",
+    "version": "Version {{version}}"
   },
   "stickyControlsBar": {
     "capoFret": "Kapodaster-Bund",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -166,7 +166,8 @@
     "returnHome": "Return to Home"
   },
   "footer": {
-    "source": "Source"
+    "source": "Source",
+    "version": "Version {{version}}"
   },
   "stickyControlsBar": {
     "capoFret": "Capo Fret",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -166,7 +166,8 @@
     "returnHome": "Volver a Inicio"
   },
   "footer": {
-    "source": "Fuente"
+    "source": "Fuente",
+    "version": "Versión {{version}}"
   },
   "stickyControlsBar": {
     "capoFret": "Traste Capo",

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -166,7 +166,8 @@
     "returnHome": "Retornar ao Início"
   },
   "footer": {
-    "source": "Fonte"
+    "source": "Fonte",
+    "version": "Versão {{version}}"
   },
   "stickyControlsBar": {
     "capoFret": "Casa do Capo",

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+declare const __APP_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,12 +2,15 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
+import { readFileSync } from "fs";
 import * as os from "os";
 import { visualizer } from 'rollup-plugin-visualizer';
 import stripTestAttributes from "./src/utils/vite-strip-test-attributes";
 import viteCompression from 'vite-plugin-compression';
 
 // https://vitejs.dev/config/
+const pkgVersion = JSON.parse(readFileSync(path.resolve(__dirname, "package.json"), "utf-8")).version;
+
 export default defineConfig(({ mode }) => {
   const isProduction = mode === 'production';
   const isHttps = process.env.VITE_HTTPS_ENABLED === 'true';
@@ -275,6 +278,7 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       // Ensure environment variables are available at build time
+      '__APP_VERSION__': JSON.stringify(pkgVersion),
       'process.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL),
       'process.env.VERCEL': JSON.stringify(process.env.VERCEL),
       // Distinguishes the production deployment from branch previews, so shared

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chordium-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chordium-monorepo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "frontend",
         "backend",
@@ -27,7 +27,7 @@
     },
     "backend": {
       "name": "chordium-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@chordium/scraping": "*",
@@ -67,7 +67,7 @@
     },
     "frontend": {
       "name": "chordium-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@chordium/scraping": "*",
         "@chordium/types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
- Footer now shows the GitHub source link on the left and the app version on the right
- App version is read from `package.json` and displayed as `v0.2.0`
- Adds a `Versioning` section to `CONTRIBUTING.md` documenting when to bump `MAJOR`/`MINOR`/`PATCH` based on Conventional Commit type
- Bumps the app to `0.2.0` as the first release under this convention
