### PR TITLE
fix: pin the translation model to an exact revision

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/services/translation/local-model-config.ts
+++ b/frontend/src/services/translation/local-model-config.ts
@@ -17,6 +17,16 @@ export const LOCAL_MODEL_ID = 'Xenova/nllb-200-distilled-600M';
  */
 export const LOCAL_MODEL_SIZE_MB = 850;
 
+/**
+ * The exact commit the weights come from. Left unpinned the runtime resolves
+ * whatever the branch points at now, so weights republished upstream can leave a
+ * device holding one file from before the change and another from after, and a
+ * session built from the pair either refuses to load or answers with nonsense.
+ * Moving to newer weights is a deliberate change here, since it costs every
+ * reader the whole download a second time.
+ */
+export const LOCAL_MODEL_REVISION = '261c31d1a5732c67cdd16d80e8d6088507c7ccea';
+
 /** The model names languages by its own script-qualified codes. */
 const MODEL_CODES: Record<string, string> = {
   en: 'eng_Latn',

--- a/frontend/src/services/translation/local-model.worker.ts
+++ b/frontend/src/services/translation/local-model.worker.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { LOCAL_MODEL_ID, LOCAL_MODEL_SIZE_MB } from './local-model-config';
+import { LOCAL_MODEL_ID, LOCAL_MODEL_REVISION, LOCAL_MODEL_SIZE_MB } from './local-model-config';
 
 /**
  * Runs the fallback translator away from the main thread.
@@ -66,6 +66,9 @@ async function getPipeline(
     pipelinePromise = (async () => {
       const { pipeline } = await import('@huggingface/transformers');
       return (await pipeline('translation', LOCAL_MODEL_ID, {
+        // Pinned so a device never ends up with weights from either side of an
+        // upstream change.
+        revision: LOCAL_MODEL_REVISION,
         // The runtime cannot build a session from the other quantisations this
         // model publishes.
         dtype: 'q8',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
- Pins the on-device translation model to an exact upstream commit. Unpinned, the runtime resolved the branch head, so republished weights could leave a device holding one file from before the change and another from after, producing a session that either fails to load or returns nonsense.
- Adopting newer weights is now a deliberate bump of `LOCAL_MODEL_REVISION`, not something that can happen to a reader mid-download.
- One-time cost: cached files are keyed by URL, so anyone who already downloaded the model fetches it once more.
- Bumped to `0.2.1`.
