### PR TITLE
fix: never ask for on-device speech recognition

### DIFF
--- a/frontend/src/components/LanguageSwitcher/index.tsx
+++ b/frontend/src/components/LanguageSwitcher/index.tsx
@@ -85,8 +85,10 @@ const LanguageSwitcher: React.FC = () => {
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
-    if (next) void refresh();
-    else {
+    if (next) {
+      void refresh();
+      void speech.refresh();
+    } else {
       setPromptedFor(null);
       setPendingSource(null);
       setPromptedForVoice(false);

--- a/frontend/src/hooks/useSpeechModel.ts
+++ b/frontend/src/hooks/useSpeechModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { isNativeRecognizerSupported } from '@/services/speech/native-recognizer';
 import {
   cancelLocalModelDownload,
@@ -22,6 +22,9 @@ export type SpeechModelStatus = 'absent' | 'downloading' | 'present';
  * Only the fallback has anything to manage. Where the browser recognises speech
  * itself there is nothing to download and nothing to remove, so the section that
  * uses this says so and offers no action.
+ *
+ * Nothing here runs until `refresh` is called: this is only relevant once the
+ * reader opens the panel that shows it, not on every page load.
  */
 export function useSpeechModel() {
   const [backend, setBackend] = useState<SpeechBackend>('none');
@@ -47,10 +50,6 @@ export function useSpeechModel() {
     // callbacks own the status until it settles.
     setStatus((current) => (current === 'downloading' ? current : present ? 'present' : 'absent'));
   }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
 
   const download = useCallback(() => {
     setProgress(0);

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -6,7 +6,6 @@ import {
   requiresDownloadConsent,
   resolveRecognizerKind,
 } from '@/services/speech/get-recognizer';
-import { probeLocalRecognition } from '@/services/speech/native-recognizer';
 import { onSpeechModelChanged, openVoiceSetup } from '@/services/speech/speech-manager';
 import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/speech/types';
 
@@ -53,11 +52,8 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       setState('unsupported');
       return;
     }
-    // Asked here, well away from any click, because listening itself cannot wait for
-    // the answer without spending the gesture it depends on.
-    await probeLocalRecognition(language);
     setState((await requiresDownloadConsent()) ? 'needs-setup' : 'idle');
-  }, [language]);
+  }, []);
 
   useEffect(() => {
     void assess();

--- a/frontend/src/services/speech/__tests__/native-recognizer.test.ts
+++ b/frontend/src/services/speech/__tests__/native-recognizer.test.ts
@@ -1,36 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { isNativeRecognizerSupported } from '../native-recognizer';
 
 /**
- * The guard is what keeps the microphone button from appearing where it could not
- * work, so both halves of it are worth pinning down.
+ * Disabled outright: several Chromium forks (Samsung Internet, and Perplexity's
+ * Comet, which reports an unmodified Chrome user agent) crash the renderer process
+ * the instant SpeechRecognition is constructed, so the API's mere presence cannot
+ * be trusted. Voice search always falls back to the bundled local model instead.
  */
 describe('isNativeRecognizerSupported', () => {
-  afterEach(() => vi.unstubAllGlobals());
-
-  it('is supported wherever the API exists in a secure context', () => {
-    vi.stubGlobal('isSecureContext', true);
-    vi.stubGlobal('SpeechRecognition', class {});
-    expect(isNativeRecognizerSupported()).toBe(true);
-  });
-
-  it('is supported through the prefixed name older builds use', () => {
-    vi.stubGlobal('isSecureContext', true);
-    vi.stubGlobal('SpeechRecognition', undefined);
-    vi.stubGlobal('webkitSpeechRecognition', class {});
-    expect(isNativeRecognizerSupported()).toBe(true);
-  });
-
-  it('is unsupported over plain http, where the microphone is refused', () => {
-    vi.stubGlobal('isSecureContext', false);
-    vi.stubGlobal('SpeechRecognition', class {});
-    expect(isNativeRecognizerSupported()).toBe(false);
-  });
-
-  it('is unsupported where the API is absent altogether', () => {
-    vi.stubGlobal('isSecureContext', true);
-    vi.stubGlobal('SpeechRecognition', undefined);
-    vi.stubGlobal('webkitSpeechRecognition', undefined);
+  it('is always unsupported, regardless of what the browser advertises', () => {
     expect(isNativeRecognizerSupported()).toBe(false);
   });
 });

--- a/frontend/src/services/speech/__tests__/native-recognizer.test.ts
+++ b/frontend/src/services/speech/__tests__/native-recognizer.test.ts
@@ -1,14 +1,98 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { isNativeRecognizerSupported } from '../native-recognizer';
 
 /**
- * Disabled outright: several Chromium forks (Samsung Internet, and Perplexity's
- * Comet, which reports an unmodified Chrome user agent) crash the renderer process
- * the instant SpeechRecognition is constructed, so the API's mere presence cannot
- * be trusted. Voice search always falls back to the bundled local model instead.
+ * The guard is what keeps the microphone button from appearing where it could not
+ * work, so both halves of it are worth pinning down.
  */
 describe('isNativeRecognizerSupported', () => {
-  it('is always unsupported, regardless of what the browser advertises', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('is supported wherever the API exists in a secure context', () => {
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', class {});
+    expect(isNativeRecognizerSupported()).toBe(true);
+  });
+
+  it('is supported through the prefixed name older builds use', () => {
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', undefined);
+    vi.stubGlobal('webkitSpeechRecognition', class {});
+    expect(isNativeRecognizerSupported()).toBe(true);
+  });
+
+  it('is unsupported over plain http, where the microphone is refused', () => {
+    vi.stubGlobal('isSecureContext', false);
+    vi.stubGlobal('SpeechRecognition', class {});
     expect(isNativeRecognizerSupported()).toBe(false);
+  });
+
+  it('is unsupported where the API is absent altogether', () => {
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', undefined);
+    vi.stubGlobal('webkitSpeechRecognition', undefined);
+    expect(isNativeRecognizerSupported()).toBe(false);
+  });
+});
+
+/**
+ * On-device recognition kills the renderer process on Chromium builds that
+ * advertise SpeechRecognition without providing media.mojom.OnDeviceSpeechRecognition
+ * (Samsung Internet, Perplexity's Comet). The crash is below the JS layer and so
+ * cannot be caught, which is why it must never be asked for in the first place.
+ */
+describe('on-device recognition', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('never probes SpeechRecognition.available()', async () => {
+    const available = vi.fn().mockResolvedValue('available');
+    class Recognition {
+      static available = available;
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult = null;
+      onerror = null;
+      onend: (() => void) | null = null;
+      start() {
+        this.onend?.();
+      }
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', Recognition);
+
+    const { createNativeRecognizer } = await import('../native-recognizer');
+    await createNativeRecognizer().listen('en').transcript;
+
+    expect(available).not.toHaveBeenCalled();
+  });
+
+  it('never sets processLocally on the recognition it starts', async () => {
+    const seen: Record<string, unknown> = {};
+    class Recognition {
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult = null;
+      onerror = null;
+      onend: (() => void) | null = null;
+      start() {
+        Object.assign(seen, { ...this });
+        this.onend?.();
+      }
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', Recognition);
+
+    const { createNativeRecognizer } = await import('../native-recognizer');
+    await createNativeRecognizer().listen('en').transcript;
+
+    expect(seen).not.toHaveProperty('processLocally');
   });
 });

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -51,15 +51,36 @@ function getConstructor(): SpeechRecognitionConstructor | null {
 }
 
 /**
+ * Whether the browser is known to have Mojo service issues with SpeechRecognition.
+ * Samsung Internet and Comet browser crash when trying to use OnDeviceSpeechRecognition,
+ * even though they report having the API.
+ */
+function isBrowserWithKnownSpeechIssues(): boolean {
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return /SamsungBrowser|CometBrowser/i.test(ua);
+}
+
+/**
  * Whether the browser can hear a search at all.
  *
  * The secure-context check is not about privacy but about whether it can run: the
  * microphone is refused over plain http on anything but localhost, so without this
  * the button would offer a recognition that cannot start.
+ *
+ * Samsung Internet and Comet browser are skipped even if they report having the API,
+ * because they crash with Mojo errors during setup.
  */
 export function isNativeRecognizerSupported(): boolean {
   if (typeof globalThis.isSecureContext === 'boolean' && !globalThis.isSecureContext) return false;
-  return getConstructor() !== null;
+  if (isBrowserWithKnownSpeechIssues()) return false;
+  const Recognition = getConstructor();
+  if (!Recognition) return false;
+  try {
+    new Recognition();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -99,14 +120,19 @@ export function createNativeRecognizer(): Recognizer {
         throw new RecognizerUnavailableError('SpeechRecognition is not available');
       }
 
-      const recognition = new Recognition();
+      let recognition;
+      try {
+        recognition = new Recognition();
+      } catch (err) {
+        throw new RecognizerUnavailableError(
+          `Failed to instantiate SpeechRecognition: ${err instanceof Error ? err.message : 'Unknown error'}`
+        );
+      }
+
       recognition.lang = language;
       recognition.continuous = false;
       recognition.interimResults = false;
       recognition.maxAlternatives = 1;
-      // Requested only where the browser has already said it can, so that the audio
-      // stays on the device and the search keeps working offline. Elsewhere the
-      // default stands, and nothing here waits on an answer.
       if (recognisesLocally) recognition.processLocally = true;
 
       let heard = '';
@@ -117,19 +143,14 @@ export function createNativeRecognizer(): Recognizer {
             if (result.isFinal) heard += result[0].transcript;
           }
         };
-        // "no-speech" and "aborted" are ordinary outcomes of a reader who changed
-        // their mind, so they settle empty rather than as failures.
         recognition.onerror = (event) => {
           const error = event.error ?? 'unknown';
           if (error === 'no-speech' || error === 'aborted') resolve('');
           else reject(new RecognizerUnavailableError(`Speech recognition failed: ${error}`));
         };
-        // Settled on end rather than on the first result, so a recognition that
-        // hears nothing finishes as an empty transcript instead of hanging.
         recognition.onend = () => resolve(heard.trim());
       });
 
-      // Started in the same turn as the click, with nothing awaited in between.
       recognition.start();
 
       return {

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -5,9 +5,10 @@ import { RecognizerUnavailableError, type RecognitionSession, type Recognizer } 
  * because it needs no download of ours, exactly as the browser's translator is
  * preferred over the model that backs it up.
  *
- * Where the browser can recognise on the device it is asked to, which also keeps
- * the feature working offline. Where it cannot, it recognises through its vendor
- * instead, which still costs the reader nothing to set up.
+ * Recognition is left to the browser's default, which recognises through its
+ * vendor. On-device recognition is deliberately never requested: asking for it
+ * kills the renderer process outright on several Chromium builds. See
+ * `createNativeRecognizer` below.
  */
 interface SpeechRecognitionAlternative {
   transcript: string;
@@ -27,7 +28,6 @@ interface SpeechRecognitionInstance {
   continuous: boolean;
   interimResults: boolean;
   maxAlternatives: number;
-  processLocally?: boolean;
   start(): void;
   stop(): void;
   abort(): void;
@@ -38,8 +38,6 @@ interface SpeechRecognitionInstance {
 
 interface SpeechRecognitionConstructor {
   new (): SpeechRecognitionInstance;
-  /** Only on builds that implement on-device recognition. */
-  available?(options: { langs: string[]; processLocally: boolean }): Promise<string>;
 }
 
 function getConstructor(): SpeechRecognitionConstructor | null {
@@ -53,46 +51,13 @@ function getConstructor(): SpeechRecognitionConstructor | null {
 /**
  * Whether the browser can hear a search at all.
  *
- * Disabled outright rather than feature-detected: several Chromium forks (Samsung
- * Internet, and Perplexity's Comet browser) terminate the renderer process with a
- * Mojo IPC error ("No binder found for interface media.mojom.OnDeviceSpeechRecognition")
- * the instant SpeechRecognition is constructed, even though the constructor itself
- * is present. That crash happens below the JS layer - no try/catch around `new
- * Recognition()` can prevent it - so it cannot be ruled out by feature-testing the
- * constructor first. Comet makes this worse by reporting an unmodified Chrome/Android
- * user agent, so it cannot be told apart from a real Chrome by user agent either.
- * Voice search always falls back to the bundled local model instead.
+ * The secure-context check is not about privacy but about whether it can run: the
+ * microphone is refused over plain http on anything but localhost, so without this
+ * the button would offer a recognition that cannot start.
  */
 export function isNativeRecognizerSupported(): boolean {
-  return false;
-}
-
-/**
- * Whether the browser said it can keep the audio on the device, as last asked.
- *
- * Held here rather than looked up when needed because the answer arrives as a
- * promise and listening cannot afford to wait for one: it has to begin in the click
- * that asked for it. Unknown counts as no, which only means on-device recognition
- * is not requested on the very first attempt.
- */
-let recognisesLocally = false;
-
-/**
- * Asks whether on-device recognition is available, for the next time listening
- * starts. Called while the button is being set up, well away from the click.
- */
-export async function probeLocalRecognition(language: string): Promise<void> {
-  const Recognition = getConstructor();
-  if (!Recognition?.available) {
-    recognisesLocally = false;
-    return;
-  }
-  try {
-    recognisesLocally =
-      (await Recognition.available({ langs: [language], processLocally: true })) === 'available';
-  } catch {
-    recognisesLocally = false;
-  }
+  if (typeof globalThis.isSecureContext === 'boolean' && !globalThis.isSecureContext) return false;
+  return getConstructor() !== null;
 }
 
 export function createNativeRecognizer(): Recognizer {
@@ -109,10 +74,16 @@ export function createNativeRecognizer(): Recognizer {
       recognition.continuous = false;
       recognition.interimResults = false;
       recognition.maxAlternatives = 1;
-      // Requested only where the browser has already said it can, so that the audio
-      // stays on the device and the search keeps working offline. Elsewhere the
-      // default stands, and nothing here waits on an answer.
-      if (recognisesLocally) recognition.processLocally = true;
+      // On-device recognition is never asked for, neither by probing
+      // SpeechRecognition.available({processLocally: true}) nor by setting
+      // `processLocally` here. Both reach for media.mojom.OnDeviceSpeechRecognition,
+      // and on Chromium builds that advertise the API without providing that
+      // interface (Samsung Internet, and Perplexity's Comet) the browser kills the
+      // renderer process on the spot: "No binder found for interface
+      // media.mojom.OnDeviceSpeechRecognition". That happens below the JS layer, so
+      // it cannot be caught, and Comet reports an unmodified Chrome user agent, so
+      // affected builds cannot be told apart from a working one beforehand. Vendor
+      // recognition, which is the default, works on all of them.
 
       let heard = '';
       const transcript = new Promise<string>((resolve, reject) => {

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -51,36 +51,20 @@ function getConstructor(): SpeechRecognitionConstructor | null {
 }
 
 /**
- * Whether the browser is known to have Mojo service issues with SpeechRecognition.
- * Samsung Internet and Comet browser crash when trying to use OnDeviceSpeechRecognition,
- * even though they report having the API.
- */
-function isBrowserWithKnownSpeechIssues(): boolean {
-  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-  return /SamsungBrowser|CometBrowser/i.test(ua);
-}
-
-/**
  * Whether the browser can hear a search at all.
  *
- * The secure-context check is not about privacy but about whether it can run: the
- * microphone is refused over plain http on anything but localhost, so without this
- * the button would offer a recognition that cannot start.
- *
- * Samsung Internet and Comet browser are skipped even if they report having the API,
- * because they crash with Mojo errors during setup.
+ * Disabled outright rather than feature-detected: several Chromium forks (Samsung
+ * Internet, and Perplexity's Comet browser) terminate the renderer process with a
+ * Mojo IPC error ("No binder found for interface media.mojom.OnDeviceSpeechRecognition")
+ * the instant SpeechRecognition is constructed, even though the constructor itself
+ * is present. That crash happens below the JS layer - no try/catch around `new
+ * Recognition()` can prevent it - so it cannot be ruled out by feature-testing the
+ * constructor first. Comet makes this worse by reporting an unmodified Chrome/Android
+ * user agent, so it cannot be told apart from a real Chrome by user agent either.
+ * Voice search always falls back to the bundled local model instead.
  */
 export function isNativeRecognizerSupported(): boolean {
-  if (typeof globalThis.isSecureContext === 'boolean' && !globalThis.isSecureContext) return false;
-  if (isBrowserWithKnownSpeechIssues()) return false;
-  const Recognition = getConstructor();
-  if (!Recognition) return false;
-  try {
-    new Recognition();
-    return true;
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 /**
@@ -120,19 +104,14 @@ export function createNativeRecognizer(): Recognizer {
         throw new RecognizerUnavailableError('SpeechRecognition is not available');
       }
 
-      let recognition;
-      try {
-        recognition = new Recognition();
-      } catch (err) {
-        throw new RecognizerUnavailableError(
-          `Failed to instantiate SpeechRecognition: ${err instanceof Error ? err.message : 'Unknown error'}`
-        );
-      }
-
+      const recognition = new Recognition();
       recognition.lang = language;
       recognition.continuous = false;
       recognition.interimResults = false;
       recognition.maxAlternatives = 1;
+      // Requested only where the browser has already said it can, so that the audio
+      // stays on the device and the search keeps working offline. Elsewhere the
+      // default stands, and nothing here waits on an answer.
       if (recognisesLocally) recognition.processLocally = true;
 
       let heard = '';
@@ -143,14 +122,19 @@ export function createNativeRecognizer(): Recognizer {
             if (result.isFinal) heard += result[0].transcript;
           }
         };
+        // "no-speech" and "aborted" are ordinary outcomes of a reader who changed
+        // their mind, so they settle empty rather than as failures.
         recognition.onerror = (event) => {
           const error = event.error ?? 'unknown';
           if (error === 'no-speech' || error === 'aborted') resolve('');
           else reject(new RecognizerUnavailableError(`Speech recognition failed: ${error}`));
         };
+        // Settled on end rather than on the first result, so a recognition that
+        // hears nothing finishes as an empty transcript instead of hanging.
         recognition.onend = () => resolve(heard.trim());
       });
 
+      // Started in the same turn as the click, with nothing awaited in between.
       recognition.start();
 
       return {


### PR DESCRIPTION
Voice search crashed the browser on page load: Samsung Internet showed "Tab has crashed", and Perplexity's Comet froze part-loaded.

**Root cause:** requesting *on-device* speech recognition kills the renderer process outright on Chromium builds that advertise `SpeechRecognition` without providing the `media.mojom.OnDeviceSpeechRecognition` interface behind it (`No binder found for interface media.mojom.OnDeviceSpeechRecognition`). The browser terminates the process at the IPC layer, below JS, so no `try`/`catch` can intercept it, and Comet reports an unmodified Chrome user agent, so affected builds can't be told apart from working ones beforehand.

It was asked for in two places, both now removed:
- `probeLocalRecognition()` called `SpeechRecognition.available({ processLocally: true })` on mount, via `useVoiceSearch` in the search tab, so the crash happened on page load before anything was clicked. This was the trigger.
- `createNativeRecognizer()` then set `processLocally` on the recognition it started.

**Fix:** never ask for on-device recognition. Vendor recognition, which is the default, works on all of these browsers, so native recognition stays enabled and no model download is forced on anyone. The trade is that audio goes to the vendor rather than staying on the device.

Also makes speech backend detection lazy: `useSpeechModel` no longer probes on every mount (it ran on every page load via the header's `LanguageSwitcher`), only when the language/voice panel is opened.

Adds regression tests pinning both halves: `available()` is never probed, and `processLocally` is never set on a started recognition.
