### PR TITLE
fix: never ask for on-device speech recognition

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -6,7 +6,6 @@ import {
   requiresDownloadConsent,
   resolveRecognizerKind,
 } from '@/services/speech/get-recognizer';
-import { probeLocalRecognition } from '@/services/speech/native-recognizer';
 import { onSpeechModelChanged, openVoiceSetup } from '@/services/speech/speech-manager';
 import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/speech/types';
 
@@ -53,11 +52,8 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       setState('unsupported');
       return;
     }
-    // Asked here, well away from any click, because listening itself cannot wait for
-    // the answer without spending the gesture it depends on.
-    await probeLocalRecognition(language);
     setState((await requiresDownloadConsent()) ? 'needs-setup' : 'idle');
-  }, [language]);
+  }, []);
 
   useEffect(() => {
     void assess();

--- a/frontend/src/services/speech/__tests__/native-recognizer.test.ts
+++ b/frontend/src/services/speech/__tests__/native-recognizer.test.ts
@@ -34,3 +34,65 @@ describe('isNativeRecognizerSupported', () => {
     expect(isNativeRecognizerSupported()).toBe(false);
   });
 });
+
+/**
+ * On-device recognition kills the renderer process on Chromium builds that
+ * advertise SpeechRecognition without providing media.mojom.OnDeviceSpeechRecognition
+ * (Samsung Internet, Perplexity's Comet). The crash is below the JS layer and so
+ * cannot be caught, which is why it must never be asked for in the first place.
+ */
+describe('on-device recognition', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('never probes SpeechRecognition.available()', async () => {
+    const available = vi.fn().mockResolvedValue('available');
+    class Recognition {
+      static available = available;
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult = null;
+      onerror = null;
+      onend: (() => void) | null = null;
+      start() {
+        this.onend?.();
+      }
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', Recognition);
+
+    const { createNativeRecognizer } = await import('../native-recognizer');
+    await createNativeRecognizer().listen('en').transcript;
+
+    expect(available).not.toHaveBeenCalled();
+  });
+
+  it('never sets processLocally on the recognition it starts', async () => {
+    const seen: Record<string, unknown> = {};
+    class Recognition {
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult = null;
+      onerror = null;
+      onend: (() => void) | null = null;
+      start() {
+        Object.assign(seen, { ...this });
+        this.onend?.();
+      }
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', Recognition);
+
+    const { createNativeRecognizer } = await import('../native-recognizer');
+    await createNativeRecognizer().listen('en').transcript;
+
+    expect(seen).not.toHaveProperty('processLocally');
+  });
+});

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -5,9 +5,10 @@ import { RecognizerUnavailableError, type RecognitionSession, type Recognizer } 
  * because it needs no download of ours, exactly as the browser's translator is
  * preferred over the model that backs it up.
  *
- * Where the browser can recognise on the device it is asked to, which also keeps
- * the feature working offline. Where it cannot, it recognises through its vendor
- * instead, which still costs the reader nothing to set up.
+ * Recognition is left to the browser's default, which recognises through its
+ * vendor. On-device recognition is deliberately never requested: asking for it
+ * kills the renderer process outright on several Chromium builds. See
+ * `createNativeRecognizer` below.
  */
 interface SpeechRecognitionAlternative {
   transcript: string;
@@ -27,7 +28,6 @@ interface SpeechRecognitionInstance {
   continuous: boolean;
   interimResults: boolean;
   maxAlternatives: number;
-  processLocally?: boolean;
   start(): void;
   stop(): void;
   abort(): void;
@@ -38,8 +38,6 @@ interface SpeechRecognitionInstance {
 
 interface SpeechRecognitionConstructor {
   new (): SpeechRecognitionInstance;
-  /** Only on builds that implement on-device recognition. */
-  available?(options: { langs: string[]; processLocally: boolean }): Promise<string>;
 }
 
 function getConstructor(): SpeechRecognitionConstructor | null {
@@ -62,34 +60,6 @@ export function isNativeRecognizerSupported(): boolean {
   return getConstructor() !== null;
 }
 
-/**
- * Whether the browser said it can keep the audio on the device, as last asked.
- *
- * Held here rather than looked up when needed because the answer arrives as a
- * promise and listening cannot afford to wait for one: it has to begin in the click
- * that asked for it. Unknown counts as no, which only means on-device recognition
- * is not requested on the very first attempt.
- */
-let recognisesLocally = false;
-
-/**
- * Asks whether on-device recognition is available, for the next time listening
- * starts. Called while the button is being set up, well away from the click.
- */
-export async function probeLocalRecognition(language: string): Promise<void> {
-  const Recognition = getConstructor();
-  if (!Recognition?.available) {
-    recognisesLocally = false;
-    return;
-  }
-  try {
-    recognisesLocally =
-      (await Recognition.available({ langs: [language], processLocally: true })) === 'available';
-  } catch {
-    recognisesLocally = false;
-  }
-}
-
 export function createNativeRecognizer(): Recognizer {
   return {
     id: 'native',
@@ -104,10 +74,16 @@ export function createNativeRecognizer(): Recognizer {
       recognition.continuous = false;
       recognition.interimResults = false;
       recognition.maxAlternatives = 1;
-      // Requested only where the browser has already said it can, so that the audio
-      // stays on the device and the search keeps working offline. Elsewhere the
-      // default stands, and nothing here waits on an answer.
-      if (recognisesLocally) recognition.processLocally = true;
+      // On-device recognition is never asked for, neither by probing
+      // SpeechRecognition.available({processLocally: true}) nor by setting
+      // `processLocally` here. Both reach for media.mojom.OnDeviceSpeechRecognition,
+      // and on Chromium builds that advertise the API without providing that
+      // interface (Samsung Internet, and Perplexity's Comet) the browser kills the
+      // renderer process on the spot: "No binder found for interface
+      // media.mojom.OnDeviceSpeechRecognition". That happens below the JS layer, so
+      // it cannot be caught, and Comet reports an unmodified Chrome user agent, so
+      // affected builds cannot be told apart from a working one beforehand. Vendor
+      // recognition, which is the default, works on all of them.
 
       let heard = '';
       const transcript = new Promise<string>((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
- Voice search crashed the browser on page load: Samsung Internet showed "Tab has crashed", Perplexity's Comet froze part-loaded. It happened before the microphone was ever pressed
- Cause: requesting *on-device* recognition kills the renderer process on Chromium builds that advertise `SpeechRecognition` without providing the `media.mojom.OnDeviceSpeechRecognition` interface behind it. The browser terminates the process at the IPC layer, below JS, so no `try`/`catch` can intercept it, and Comet reports an unmodified Chrome user agent, so affected builds can't be detected beforehand
- It was requested in two places, both removed: `probeLocalRecognition()` called `SpeechRecognition.available({ processLocally: true })` from `useVoiceSearch` on mount (the actual trigger), and `createNativeRecognizer()` then set `processLocally` on the recognition it started
- Native recognition is untouched and still used wherever the browser exposes the API, so no model download is forced on anyone. The only trade is that audio goes to the browser vendor rather than staying on device
- Adds regression tests pinning both halves: `available()` is never probed, and `processLocally` is never set on a started recognition
- Bumps `0.4.0` to `0.4.1`
