### PR TITLE
fix: voice search first press, and stuck service workers

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/LanguageSwitcher/index.tsx
+++ b/frontend/src/components/LanguageSwitcher/index.tsx
@@ -183,25 +183,27 @@ const LanguageSwitcher: React.FC = () => {
   // reported here so the one place that manages languages manages this too, which is
   // also where the microphone sends a reader who still needs the download.
   const speechPercent = Math.round(speech.progress * 100);
-  const speechSection = speech.backend !== "none" && (
+  /*
+   * Only shown where there is something to do about it. A browser that recognises
+   * speech itself needs nothing downloaded, nothing removed and nothing decided, so
+   * saying as much was telling the reader about a setting that is not a setting.
+   *
+   * One button carries the whole state: it starts the download, then fills with its
+   * progress and offers to stop, then offers to remove it.
+   */
+  const speechSection = speech.backend === "local-model" && (
     <div className="border-t px-4 py-3">
       <p className="flex items-center gap-1.5 text-sm font-medium">
         <Mic className="h-3.5 w-3.5" />
         {t("voiceSearch.heading")}
       </p>
       <p className="mt-1 text-xs text-muted-foreground">
-        {speech.backend === "native"
-          ? t("voiceSearch.hintNative")
-          : speech.status === "present"
-            ? t("voiceSearch.hintReady", { size: speech.sizeMb })
-            : t("voiceSearch.hint", { size: speech.sizeMb })}
+        {speech.status === "present"
+          ? t("voiceSearch.hintReady", { size: speech.sizeMb })
+          : t("voiceSearch.hint", { size: speech.sizeMb })}
       </p>
 
-      {/* Only the fallback has anything to act on. One button carries its whole
-          state: it starts the download, then fills with its progress and offers to
-          stop, then offers to remove it. */}
-      {speech.backend === "local-model" && (
-        <Button
+      <Button
           variant="outline"
           size="sm"
           className={cn(
@@ -238,9 +240,8 @@ const LanguageSwitcher: React.FC = () => {
                 {t("voiceSearch.download")}
               </>
             )}
-          </span>
-        </Button>
-      )}
+        </span>
+      </Button>
     </div>
   );
 

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,11 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Fades, and does not travel. It used to slide in from the top left and
+        // zoom, which read as the dialog arriving from somewhere off screen rather
+        // than being asked for, and matched nothing else here. The centring
+        // translate stays a plain transform: it positions the dialog, unanimated.
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
         className
       )}
       {...props}

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -5,12 +5,13 @@ const canListen = vi.hoisted(() => vi.fn());
 const requiresDownloadConsent = vi.hoisted(() => vi.fn());
 const resolveRecognizerKind = vi.hoisted(() => vi.fn());
 const createRecognizer = vi.hoisted(() => vi.fn());
-const isMicrophoneGranted = vi.hoisted(() => vi.fn());
+const getMicrophonePermission = vi.hoisted(() => vi.fn());
+const getMicrophoneResetPlatform = vi.hoisted(() => vi.fn(() => 'chrome'));
 const forgetMicrophoneGrant = vi.hoisted(() => vi.fn());
 const requestMicrophone = vi.hoisted(() => vi.fn());
 const releaseMicrophone = vi.hoisted(() => vi.fn());
 
-vi.mock('sonner', () => ({ toast: { error: toastError } }));
+vi.mock('sonner', () => ({ toast: { error: toastError, dismiss: vi.fn() } }));
 
 // Keys stand in for the copy, so a message only needs to be distinguishable.
 vi.mock('react-i18next', () => ({
@@ -27,7 +28,8 @@ vi.mock('@/services/speech/get-recognizer', () => ({
 }));
 
 vi.mock('@/services/speech/microphone-permission', () => ({
-  isMicrophoneGranted,
+  getMicrophonePermission,
+  getMicrophoneResetPlatform,
   forgetMicrophoneGrant,
   requestMicrophone,
   releaseMicrophone,
@@ -48,7 +50,7 @@ describe('useVoiceSearch failures are shown to the reader', () => {
     canListen.mockReturnValue(true);
     requiresDownloadConsent.mockResolvedValue(false);
     resolveRecognizerKind.mockReturnValue('native');
-    isMicrophoneGranted.mockResolvedValue(true);
+    getMicrophonePermission.mockResolvedValue('granted');
   });
 
   /**
@@ -72,8 +74,8 @@ describe('useVoiceSearch failures are shown to the reader', () => {
     return hook;
   }
 
-  it('says the microphone was refused, which the reader can act on', async () => {
-    listenWith(() => Promise.reject(new MicrophoneUnavailableError('refused')));
+  it('says the microphone is missing, which is not something settings will fix', async () => {
+    listenWith(() => Promise.reject(new MicrophoneUnavailableError('no device', false)));
 
     await startedHook();
 
@@ -84,8 +86,8 @@ describe('useVoiceSearch failures are shown to the reader', () => {
     );
   });
 
-  it('asks for the microphone again once it has been refused', async () => {
-    listenWith(() => Promise.reject(new MicrophoneUnavailableError('refused')));
+  it('asks for the microphone again where it went missing rather than being refused', async () => {
+    listenWith(() => Promise.reject(new MicrophoneUnavailableError('no device', false)));
 
     const { result } = await startedHook();
 
@@ -148,7 +150,7 @@ describe('useVoiceSearch listens as soon as the microphone is allowed', () => {
     requiresDownloadConsent.mockResolvedValue(false);
     resolveRecognizerKind.mockReturnValue('native');
     // Not yet allowed, so the first press is the one that asks.
-    isMicrophoneGranted.mockResolvedValue(false);
+    getMicrophonePermission.mockResolvedValue('prompt');
     requestMicrophone.mockResolvedValue(stream);
     createRecognizer.mockReturnValue({
       id: 'native',
@@ -200,5 +202,70 @@ describe('useVoiceSearch listens as soon as the microphone is allowed', () => {
     await waitFor(() => expect(result.current.state).toBe('idle'));
     expect(toastError).not.toHaveBeenCalled();
     expect(releaseMicrophone).toHaveBeenCalled();
+  });
+});
+
+/**
+ * A refused microphone cannot be asked for again: the browser answers no without so
+ * much as a prompt. Only browser settings undo it, and an average reader does not know
+ * where those are, so the way back has to be spelled out or voice search is over for
+ * them for good.
+ */
+describe('useVoiceSearch explains a refused microphone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canListen.mockReturnValue(true);
+    requiresDownloadConsent.mockResolvedValue(false);
+    resolveRecognizerKind.mockReturnValue('native');
+    getMicrophoneResetPlatform.mockReturnValue('ios');
+  });
+
+  it('says so on the button, rather than inviting a press that does nothing', async () => {
+    getMicrophonePermission.mockResolvedValue('denied');
+
+    const { result } = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+
+    await waitFor(() => expect(result.current.state).toBe('blocked'));
+  });
+
+  it('gives the steps for this browser, and keeps them until dismissed', async () => {
+    getMicrophonePermission.mockResolvedValue('denied');
+    const { result } = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(result.current.state).toBe('blocked'));
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        'notifications:voiceMicrophoneBlocked',
+        expect.objectContaining({
+          description: 'notifications:voiceMicrophoneBlockedIos',
+          duration: Infinity,
+        })
+      )
+    );
+  });
+
+  /**
+   * Refused at the prompt rather than beforehand, which is the mistaken tap this is
+   * really for: the reader meant to allow it and hit the wrong button.
+   */
+  it('explains itself when the prompt itself is refused', async () => {
+    getMicrophonePermission.mockResolvedValue('prompt');
+    requestMicrophone.mockRejectedValue(new MicrophoneUnavailableError('refused', true));
+    const { result } = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(result.current.state).toBe('needs-permission'));
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('blocked'));
+    expect(toastError).toHaveBeenCalledWith(
+      'notifications:voiceMicrophoneBlocked',
+      expect.objectContaining({ description: 'notifications:voiceMicrophoneBlockedIos' })
+    );
   });
 });

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -1,0 +1,131 @@
+import { vi } from 'vitest';
+
+const toastError = vi.hoisted(() => vi.fn());
+const canListen = vi.hoisted(() => vi.fn());
+const requiresDownloadConsent = vi.hoisted(() => vi.fn());
+const resolveRecognizerKind = vi.hoisted(() => vi.fn());
+const createRecognizer = vi.hoisted(() => vi.fn());
+const isMicrophoneGranted = vi.hoisted(() => vi.fn());
+const forgetMicrophoneGrant = vi.hoisted(() => vi.fn());
+
+vi.mock('sonner', () => ({ toast: { error: toastError } }));
+
+// Keys stand in for the copy, so a message only needs to be distinguishable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { resolvedLanguage: 'en', t: (key: string) => key },
+  }),
+}));
+
+vi.mock('@/services/speech/get-recognizer', () => ({
+  canListen,
+  requiresDownloadConsent,
+  resolveRecognizerKind,
+  createRecognizer,
+}));
+
+vi.mock('@/services/speech/microphone-permission', () => ({
+  isMicrophoneGranted,
+  forgetMicrophoneGrant,
+  requestMicrophone: vi.fn(),
+}));
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useVoiceSearch } from '../useVoiceSearch';
+import { MicrophoneUnavailableError, RecognizerUnavailableError } from '@/services/speech/types';
+
+/**
+ * A failure used to leave the button quietly sliding back to where it started, so a
+ * reader had no way of telling whether anything had been heard.
+ */
+describe('useVoiceSearch failures are shown to the reader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canListen.mockReturnValue(true);
+    requiresDownloadConsent.mockResolvedValue(false);
+    resolveRecognizerKind.mockReturnValue('native');
+    isMicrophoneGranted.mockResolvedValue(true);
+  });
+
+  /**
+   * Listens, then settles however the test asks. The outcome is built inside listen so
+   * that a rejection is created only once there is something about to handle it: built
+   * ahead of time it would sit unhandled in between and be reported as such.
+   */
+  function listenWith(outcome: () => Promise<string>) {
+    createRecognizer.mockReturnValue({
+      id: 'native',
+      listen: () => ({ stop: vi.fn(), abort: vi.fn(), transcript: outcome() }),
+    });
+  }
+
+  async function startedHook() {
+    const hook = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(hook.result.current.state).toBe('idle'));
+    await act(async () => {
+      hook.result.current.start();
+    });
+    return hook;
+  }
+
+  it('says the microphone was refused, which the reader can act on', async () => {
+    listenWith(() => Promise.reject(new MicrophoneUnavailableError('refused')));
+
+    await startedHook();
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith('notifications:voiceMicrophoneDenied', {
+        description: 'notifications:voiceMicrophoneDeniedDesc',
+      })
+    );
+  });
+
+  it('asks for the microphone again once it has been refused', async () => {
+    listenWith(() => Promise.reject(new MicrophoneUnavailableError('refused')));
+
+    const { result } = await startedHook();
+
+    await waitFor(() => expect(result.current.state).toBe('needs-permission'));
+    expect(forgetMicrophoneGrant).toHaveBeenCalled();
+  });
+
+  it('says any other failure differently, since the reader cannot act on it', async () => {
+    listenWith(() => Promise.reject(new RecognizerUnavailableError('broke')));
+
+    await startedHook();
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith('notifications:voiceSearchFailed', {
+        description: 'notifications:voiceSearchFailedDesc',
+      })
+    );
+  });
+
+  /**
+   * Cleared once shown, so that the same failure twice running is said twice rather
+   * than going unmentioned the second time for not having changed.
+   */
+  it('says the same failure again when it happens again', async () => {
+    listenWith(() => Promise.reject(new RecognizerUnavailableError('broke')));
+    const { result } = await startedHook();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+    listenWith(() => Promise.reject(new RecognizerUnavailableError('broke')));
+    await waitFor(() => expect(result.current.state).toBe('idle'));
+    await act(async () => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(2));
+  });
+
+  it('says nothing where there was no failure', async () => {
+    listenWith(() => Promise.resolve('hotel california'));
+
+    await startedHook();
+
+    await waitFor(() => expect(toastError).not.toHaveBeenCalled());
+  });
+});

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -348,6 +348,8 @@ describe('useVoiceSearch explains the lingering microphone indicator', () => {
     await waitFor(() =>
       expect(toastInfo).toHaveBeenCalledWith('notifications:voiceMicrophoneLingers', {
         description: 'notifications:voiceMicrophoneLingersDesc',
+        // Two sentences about something alarming, so longer than a toast's usual few.
+        duration: 7000,
       })
     );
   });

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -7,6 +7,8 @@ const resolveRecognizerKind = vi.hoisted(() => vi.fn());
 const createRecognizer = vi.hoisted(() => vi.fn());
 const isMicrophoneGranted = vi.hoisted(() => vi.fn());
 const forgetMicrophoneGrant = vi.hoisted(() => vi.fn());
+const requestMicrophone = vi.hoisted(() => vi.fn());
+const releaseMicrophone = vi.hoisted(() => vi.fn());
 
 vi.mock('sonner', () => ({ toast: { error: toastError } }));
 
@@ -27,7 +29,8 @@ vi.mock('@/services/speech/get-recognizer', () => ({
 vi.mock('@/services/speech/microphone-permission', () => ({
   isMicrophoneGranted,
   forgetMicrophoneGrant,
-  requestMicrophone: vi.fn(),
+  requestMicrophone,
+  releaseMicrophone,
 }));
 
 import { act, renderHook, waitFor } from '@testing-library/react';
@@ -127,5 +130,75 @@ describe('useVoiceSearch failures are shown to the reader', () => {
     await startedHook();
 
     await waitFor(() => expect(toastError).not.toHaveBeenCalled());
+  });
+});
+
+/**
+ * The reader presses once: the prompt answers, and what they say next is already
+ * being heard. Asking and then waiting to be asked again was a press that earned
+ * nothing.
+ */
+describe('useVoiceSearch listens as soon as the microphone is allowed', () => {
+  const stop = vi.fn();
+  const stream = { getTracks: () => [{ stop }] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canListen.mockReturnValue(true);
+    requiresDownloadConsent.mockResolvedValue(false);
+    resolveRecognizerKind.mockReturnValue('native');
+    // Not yet allowed, so the first press is the one that asks.
+    isMicrophoneGranted.mockResolvedValue(false);
+    requestMicrophone.mockResolvedValue(stream);
+    createRecognizer.mockReturnValue({
+      id: 'native',
+      listen: () => ({ stop: vi.fn(), abort: vi.fn(), transcript: new Promise<string>(() => {}) }),
+    });
+  });
+
+  async function pressOnce() {
+    const hook = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(hook.result.current.state).toBe('needs-permission'));
+    await act(async () => {
+      hook.result.current.start();
+    });
+    return hook;
+  }
+
+  it('begins listening on the same press that asked', async () => {
+    const { result } = await pressOnce();
+
+    await waitFor(() => expect(result.current.state).toBe('listening'));
+  });
+
+  /**
+   * Released only once listening holds the device itself, so it never goes down and
+   * comes back up in between, which is what left the first recording silent.
+   */
+  it('keeps the microphone open across the handover', async () => {
+    await pressOnce();
+
+    await waitFor(() => expect(createRecognizer).toHaveBeenCalled());
+    expect(releaseMicrophone).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Some browsers insist the press itself begins the recognition, and refuse one
+   * started after an await. That is our attempt failing, not the reader's, so it is
+   * left ready to be pressed rather than reported.
+   */
+  it('waits to be pressed again where the browser refuses to start itself', async () => {
+    createRecognizer.mockReturnValue({
+      id: 'native',
+      listen: () => {
+        throw new Error('not allowed without a gesture');
+      },
+    });
+
+    const { result } = await pressOnce();
+
+    await waitFor(() => expect(result.current.state).toBe('idle'));
+    expect(toastError).not.toHaveBeenCalled();
+    expect(releaseMicrophone).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -249,6 +249,28 @@ describe('useVoiceSearch explains a refused microphone', () => {
   });
 
   /**
+   * Pressing a blocked microphone is the natural thing to do, and doing it a few times
+   * over should not bury the page in identical toasts. The id is what sonner replaces
+   * on, so the same one every time leaves one toast however many presses there were.
+   */
+  it('replaces its own telling rather than stacking one per press', async () => {
+    getMicrophonePermission.mockResolvedValue('denied');
+    const { result } = renderHook(() => useVoiceSearch({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(result.current.state).toBe('blocked'));
+
+    for (let press = 0; press < 3; press += 1) {
+      await act(async () => {
+        result.current.start();
+      });
+    }
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(3));
+    const ids = toastError.mock.calls.map(([, options]) => options.id);
+    expect(new Set(ids).size).toBe(1);
+    expect(ids[0]).toBeTruthy();
+  });
+
+  /**
    * Refused at the prompt rather than beforehand, which is the mistaken tap this is
    * really for: the reader meant to allow it and hit the wrong button.
    */

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 const toastError = vi.hoisted(() => vi.fn());
+const toastInfo = vi.hoisted(() => vi.fn());
 const canListen = vi.hoisted(() => vi.fn());
 const requiresDownloadConsent = vi.hoisted(() => vi.fn());
 const resolveRecognizerKind = vi.hoisted(() => vi.fn());
@@ -11,7 +12,7 @@ const forgetMicrophoneGrant = vi.hoisted(() => vi.fn());
 const requestMicrophone = vi.hoisted(() => vi.fn());
 const releaseMicrophone = vi.hoisted(() => vi.fn());
 
-vi.mock('sonner', () => ({ toast: { error: toastError, dismiss: vi.fn() } }));
+vi.mock('sonner', () => ({ toast: { error: toastError, info: toastInfo, dismiss: vi.fn() } }));
 
 // Keys stand in for the copy, so a message only needs to be distinguishable.
 vi.mock('react-i18next', () => ({
@@ -174,14 +175,24 @@ describe('useVoiceSearch listens as soon as the microphone is allowed', () => {
   });
 
   /**
-   * Released only once listening holds the device itself, so it never goes down and
-   * comes back up in between, which is what left the first recording silent.
+   * Android hands the microphone to one holder at a time, so ours has to be let go
+   * before listening reaches for it. Held across the handover, its recogniser started
+   * against a device it could not have and reported silence on every browser there.
    */
-  it('keeps the microphone open across the handover', async () => {
+  it('lets go of the microphone before listening reaches for it', async () => {
+    const order: string[] = [];
+    releaseMicrophone.mockImplementation(() => void order.push('release'));
+    createRecognizer.mockImplementation(() => {
+      order.push('listen');
+      return {
+        id: 'native',
+        listen: () => ({ stop: vi.fn(), abort: vi.fn(), transcript: new Promise<string>(() => {}) }),
+      };
+    });
+
     await pressOnce();
 
-    await waitFor(() => expect(createRecognizer).toHaveBeenCalled());
-    expect(releaseMicrophone).not.toHaveBeenCalled();
+    await waitFor(() => expect(order).toEqual(['release', 'listen']));
   });
 
   /**
@@ -200,8 +211,11 @@ describe('useVoiceSearch listens as soon as the microphone is allowed', () => {
     const { result } = await pressOnce();
 
     await waitFor(() => expect(result.current.state).toBe('idle'));
+    // Said in words, because a pulsing ring beside a microphone reads as recording.
+    expect(toastInfo).toHaveBeenCalledWith('notifications:voiceMicrophoneReady', {
+      description: 'notifications:voiceMicrophoneReadyDesc',
+    });
     expect(toastError).not.toHaveBeenCalled();
-    expect(releaseMicrophone).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
+++ b/frontend/src/hooks/__tests__/useVoiceSearch.errors.test.ts
@@ -305,3 +305,89 @@ describe('useVoiceSearch explains a refused microphone', () => {
     );
   });
 });
+
+/**
+ * WebKit never unsets its audio session after speech recognition finishes, so macOS and
+ * iOS keep showing the microphone as in use until the tab is reloaded. Nothing is being
+ * recorded, but an app that looks like it is still listening reads as one that is, so it
+ * is worth a sentence. See bugs.webkit.org/show_bug.cgi?id=219671.
+ */
+describe('useVoiceSearch explains the lingering microphone indicator', () => {
+  let freshHook: typeof useVoiceSearch;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // The notice is said once a session, and a session is module state, so each of
+    // these takes its own copy of the module or the first would silence the rest.
+    vi.resetModules();
+    ({ useVoiceSearch: freshHook } = await import('../useVoiceSearch'));
+    canListen.mockReturnValue(true);
+    requiresDownloadConsent.mockResolvedValue(false);
+    resolveRecognizerKind.mockReturnValue('native');
+    getMicrophonePermission.mockResolvedValue('granted');
+    createRecognizer.mockReturnValue({
+      id: 'native',
+      listen: () => ({ stop: vi.fn(), abort: vi.fn(), transcript: Promise.resolve('rihanna') }),
+    });
+  });
+
+  async function searchOnce() {
+    const hook = renderHook(() => freshHook({ onTranscript: vi.fn() }));
+    await waitFor(() => expect(hook.result.current.state).toBe('idle'));
+    await act(async () => {
+      hook.result.current.start();
+    });
+    return hook;
+  }
+
+  it('says so on WebKit, where the indicator will still be lit', async () => {
+    getMicrophoneResetPlatform.mockReturnValue('safari');
+
+    await searchOnce();
+
+    await waitFor(() =>
+      expect(toastInfo).toHaveBeenCalledWith('notifications:voiceMicrophoneLingers', {
+        description: 'notifications:voiceMicrophoneLingersDesc',
+      })
+    );
+  });
+
+  /** Every browser on iOS is WebKit underneath, so it is not Safari's alone. */
+  it('says so on iOS too, whichever browser is wrapping WebKit', async () => {
+    getMicrophoneResetPlatform.mockReturnValue('ios');
+
+    await searchOnce();
+
+    await waitFor(() => expect(toastInfo).toHaveBeenCalled());
+  });
+
+  /** Reminding them after every search would be nagging about something unchanging. */
+  it('says it once a session, not once a search', async () => {
+    getMicrophoneResetPlatform.mockReturnValue('safari');
+
+    await searchOnce();
+    await waitFor(() => expect(toastInfo).toHaveBeenCalledTimes(1));
+    await searchOnce();
+
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet where the browser closes the microphone properly', async () => {
+    getMicrophoneResetPlatform.mockReturnValue('chrome');
+
+    await searchOnce();
+
+    await waitFor(() => expect(createRecognizer).toHaveBeenCalled());
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet where the model is doing the listening, since it closes the device', async () => {
+    getMicrophoneResetPlatform.mockReturnValue('safari');
+    resolveRecognizerKind.mockReturnValue('local-model');
+
+    await searchOnce();
+
+    await waitFor(() => expect(createRecognizer).toHaveBeenCalled());
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import {
   canListen,
   createRecognizer,
@@ -191,5 +192,27 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     []
   );
 
-  return { state, error, start, stop, clearError: () => setError(null) };
+  /**
+   * A failure the reader can see, rather than a button that quietly slides back to
+   * where it started and leaves them guessing whether it heard anything.
+   *
+   * Cleared once shown so that the same failure twice running is said twice: without
+   * that, a second identical failure would not change the value and would go
+   * unmentioned.
+   */
+  useEffect(() => {
+    if (!error) return;
+    if (error === 'microphone') {
+      toast.error(i18n.t('notifications:voiceMicrophoneDenied'), {
+        description: i18n.t('notifications:voiceMicrophoneDeniedDesc'),
+      });
+    } else {
+      toast.error(i18n.t('notifications:voiceSearchFailed'), {
+        description: i18n.t('notifications:voiceSearchFailedDesc'),
+      });
+    }
+    setError(null);
+  }, [error, i18n]);
+
+  return { state, error, start, stop };
 }

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -80,9 +80,6 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
   // Guards against a second press asking for the microphone while the first prompt is
   // still up, which the state cannot express without misdescribing itself.
   const requestingRef = useRef(false);
-  // Held from the moment permission is granted until listening has its own hold on the
-  // device, so that it is never taken down and brought back up in between.
-  const heldStreamRef = useRef<MediaStream | null>(null);
 
   // Kept in a ref so a transcript arriving late calls the current handler rather than
   // the one that happened to be in scope when listening started.
@@ -133,12 +130,6 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     sessionRef.current.stop();
   }, []);
 
-  const releaseHeldMicrophone = useCallback(() => {
-    if (!heldStreamRef.current) return;
-    releaseMicrophone(heldStreamRef.current);
-    heldStreamRef.current = null;
-  }, []);
-
   /**
    * Opens the microphone and hands back what was heard.
    *
@@ -161,7 +152,6 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
         } catch (cause) {
           setState('idle');
           if (!quietly) setError('failed');
-          releaseHeldMicrophone();
           console.error('Voice search could not start:', cause);
           return false;
         }
@@ -178,12 +168,10 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
               attempt();
               return;
             }
-            releaseHeldMicrophone();
             if (transcript) onTranscriptRef.current(transcript);
           })
           .catch((cause: unknown) => {
             sessionRef.current = null;
-            releaseHeldMicrophone();
             const unavailable = cause instanceof MicrophoneUnavailableError;
             // A grant withdrawn in browser settings after the fact leaves a remembered
             // one that is no longer true, so it is dropped and asked for again rather
@@ -200,7 +188,7 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
 
       return attempt();
     },
-    [language, releaseHeldMicrophone]
+    [language]
   );
 
   /**
@@ -238,11 +226,20 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       requestingRef.current = true;
       void requestMicrophone()
         .then((stream) => {
-          heldStreamRef.current = stream;
+          // Let go before listening takes over, not after. Android hands the
+          // microphone to one holder at a time, so keeping ours open left its
+          // recogniser listening to nothing at all: it started, heard silence and
+          // reported it, on every browser there. Desktop shares the device happily,
+          // which is why one press worked there and nowhere else.
+          releaseMicrophone(stream);
           // Quietly, because a browser that insists on the press itself will refuse
-          // this and that is not a failure worth reporting: it leaves the button idle
-          // and pulsing, which asks for the press it wants.
-          if (!beginListening(true)) releaseHeldMicrophone();
+          // this and that is not a failure worth reporting. The reader is told it is
+          // ready and asked for the press the browser wants instead.
+          if (!beginListening(true)) {
+            toast.info(i18n.t('notifications:voiceMicrophoneReady'), {
+              description: i18n.t('notifications:voiceMicrophoneReadyDesc'),
+            });
+          }
         })
         .catch((cause: unknown) => {
           const refused = cause instanceof MicrophoneUnavailableError && cause.denied;
@@ -259,7 +256,7 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     if (state !== 'idle') return;
 
     beginListening();
-  }, [beginListening, releaseHeldMicrophone, state]);
+  }, [beginListening, i18n, state]);
 
   // A microphone left open when the page moves on would keep recording, so any session
   // still running is abandoned on the way out.
@@ -267,8 +264,6 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     () => () => {
       sessionRef.current?.abort();
       sessionRef.current = null;
-      if (heldStreamRef.current) releaseMicrophone(heldStreamRef.current);
-      heldStreamRef.current = null;
     },
     []
   );

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -9,9 +9,11 @@ import {
 } from '@/services/speech/get-recognizer';
 import {
   forgetMicrophoneGrant,
-  isMicrophoneGranted,
+  getMicrophonePermission,
+  getMicrophoneResetPlatform,
   releaseMicrophone,
   requestMicrophone,
+  type MicrophoneResetPlatform,
 } from '@/services/speech/microphone-permission';
 import { onSpeechModelChanged, openVoiceSetup } from '@/services/speech/speech-manager';
 import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/speech/types';
@@ -21,6 +23,7 @@ import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/
  * - "unsupported": this browser cannot hear one at all.
  * - "needs-setup": it could, once the fallback model has been downloaded.
  * - "needs-permission": it could, once the reader has allowed the microphone.
+ * - "blocked": the microphone was refused, and only browser settings can undo it.
  * - "idle": ready, waiting to be asked.
  * - "listening": the microphone is open.
  * - "working": listening has stopped and the words are being made out.
@@ -29,9 +32,23 @@ export type VoiceSearchState =
   | 'unsupported'
   | 'needs-setup'
   | 'needs-permission'
+  | 'blocked'
   | 'idle'
   | 'listening'
   | 'working';
+
+/**
+ * Where each platform hides the setting. Spelled out rather than assembled from the
+ * platform name so that every key can be found by searching for it.
+ */
+const RESET_HINTS: Record<MicrophoneResetPlatform, string> = {
+  ios: 'notifications:voiceMicrophoneBlockedIos',
+  safari: 'notifications:voiceMicrophoneBlockedSafari',
+  android: 'notifications:voiceMicrophoneBlockedAndroid',
+  chrome: 'notifications:voiceMicrophoneBlockedChrome',
+  firefox: 'notifications:voiceMicrophoneBlockedFirefox',
+  generic: 'notifications:voiceMicrophoneBlockedGeneric',
+};
 
 interface UseVoiceSearchOptions {
   /** Called with the transcript, once there is one worth acting on. */
@@ -79,9 +96,16 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     // Only the browser's own recogniser needs asking ahead of the press. The model
     // opens the microphone itself and waits for the grant before it records, so it
     // has nothing to race.
-    if (resolveRecognizerKind() === 'native' && !(await isMicrophoneGranted())) {
-      setState('needs-permission');
-      return;
+    if (resolveRecognizerKind() === 'native') {
+      const permission = await getMicrophonePermission();
+      if (permission === 'denied') {
+        setState('blocked');
+        return;
+      }
+      if (permission === 'prompt') {
+        setState('needs-permission');
+        return;
+      }
     }
     setState('idle');
   }, []);
@@ -153,13 +177,14 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
           .catch((cause: unknown) => {
             sessionRef.current = null;
             releaseHeldMicrophone();
-            const refused = cause instanceof MicrophoneUnavailableError;
+            const unavailable = cause instanceof MicrophoneUnavailableError;
             // A grant withdrawn in browser settings after the fact leaves a remembered
             // one that is no longer true, so it is dropped and asked for again rather
             // than kept and retried against a microphone that will keep refusing.
-            if (refused) forgetMicrophoneGrant();
-            setState(refused ? 'needs-permission' : 'idle');
-            setError(refused ? 'microphone' : 'failed');
+            if (unavailable) forgetMicrophoneGrant();
+            const refused = unavailable && cause.denied;
+            setState(refused ? 'blocked' : unavailable ? 'needs-permission' : 'idle');
+            setError(refused ? 'blocked' : unavailable ? 'microphone' : 'failed');
             console.error('Voice search failed:', cause);
           });
 
@@ -187,6 +212,14 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       return;
     }
 
+    // Asking again would be refused without so much as a prompt, so the steps out of
+    // it are repeated instead. Said on a press rather than on sight, since that is when
+    // the reader has just asked to be heard and is looking for why they were not.
+    if (state === 'blocked') {
+      setError('blocked');
+      return;
+    }
+
     // Permission is the one thing here that has to be waited for, so it is asked for
     // on its own and listening follows it directly. The reader presses once: the
     // prompt answers, and what they say next is already being heard.
@@ -205,7 +238,9 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
           if (!beginListening(true)) releaseHeldMicrophone();
         })
         .catch((cause: unknown) => {
-          setError('microphone');
+          const refused = cause instanceof MicrophoneUnavailableError && cause.denied;
+          if (refused) setState('blocked');
+          setError(refused ? 'blocked' : 'microphone');
           console.error('The microphone was not allowed:', cause);
         })
         .finally(() => {
@@ -241,7 +276,18 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
    */
   useEffect(() => {
     if (!error) return;
-    if (error === 'microphone') {
+    if (error === 'blocked') {
+      // Kept until dismissed: steps that fade before they are read are no steps at
+      // all, and there is nothing to retry in the meantime.
+      const shown = toast.error(i18n.t('notifications:voiceMicrophoneBlocked'), {
+        description: i18n.t(RESET_HINTS[getMicrophoneResetPlatform()]),
+        duration: Infinity,
+        action: {
+          label: i18n.t('notifications:voiceMicrophoneBlockedDismiss'),
+          onClick: () => toast.dismiss(shown),
+        },
+      });
+    } else if (error === 'microphone') {
       toast.error(i18n.t('notifications:voiceMicrophoneDenied'), {
         description: i18n.t('notifications:voiceMicrophoneDeniedDesc'),
       });

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -6,6 +6,11 @@ import {
   requiresDownloadConsent,
   resolveRecognizerKind,
 } from '@/services/speech/get-recognizer';
+import {
+  forgetMicrophoneGrant,
+  isMicrophoneGranted,
+  requestMicrophone,
+} from '@/services/speech/microphone-permission';
 import { onSpeechModelChanged, openVoiceSetup } from '@/services/speech/speech-manager';
 import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/speech/types';
 
@@ -13,11 +18,18 @@ import { MicrophoneUnavailableError, type RecognitionSession } from '@/services/
  * Where a spoken search has got to:
  * - "unsupported": this browser cannot hear one at all.
  * - "needs-setup": it could, once the fallback model has been downloaded.
+ * - "needs-permission": it could, once the reader has allowed the microphone.
  * - "idle": ready, waiting to be asked.
  * - "listening": the microphone is open.
  * - "working": listening has stopped and the words are being made out.
  */
-export type VoiceSearchState = 'unsupported' | 'needs-setup' | 'idle' | 'listening' | 'working';
+export type VoiceSearchState =
+  | 'unsupported'
+  | 'needs-setup'
+  | 'needs-permission'
+  | 'idle'
+  | 'listening'
+  | 'working';
 
 interface UseVoiceSearchOptions {
   /** Called with the transcript, once there is one worth acting on. */
@@ -39,6 +51,9 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
   const [state, setState] = useState<VoiceSearchState>('unsupported');
   const [error, setError] = useState<string | null>(null);
   const sessionRef = useRef<RecognitionSession | null>(null);
+  // Guards against a second press asking for the microphone while the first prompt is
+  // still up, which the state cannot express without misdescribing itself.
+  const requestingRef = useRef(false);
 
   // Kept in a ref so a transcript arriving late calls the current handler rather than
   // the one that happened to be in scope when listening started.
@@ -52,7 +67,18 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       setState('unsupported');
       return;
     }
-    setState((await requiresDownloadConsent()) ? 'needs-setup' : 'idle');
+    if (await requiresDownloadConsent()) {
+      setState('needs-setup');
+      return;
+    }
+    // Only the browser's own recogniser needs asking ahead of the press. The model
+    // opens the microphone itself and waits for the grant before it records, so it
+    // has nothing to race.
+    if (resolveRecognizerKind() === 'native' && !(await isMicrophoneGranted())) {
+      setState('needs-permission');
+      return;
+    }
+    setState('idle');
   }, []);
 
   useEffect(() => {
@@ -86,6 +112,29 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       openVoiceSetup();
       return;
     }
+
+    // Asking is its own press, because it is the one thing here that has to be waited
+    // for. A recognition started in this press would run while the prompt is still up
+    // and hear nothing, which is the whole bug this avoids. The press after this one
+    // starts listening with the microphone already open.
+    if (state === 'needs-permission') {
+      // The state is left alone while the prompt is up: "working" would say the words
+      // are being made out, which is not what is happening. A second press would only
+      // ask twice, so it is dropped instead.
+      if (requestingRef.current) return;
+      requestingRef.current = true;
+      void requestMicrophone()
+        .then(() => setState('idle'))
+        .catch((cause: unknown) => {
+          setError('microphone');
+          console.error('The microphone was not allowed:', cause);
+        })
+        .finally(() => {
+          requestingRef.current = false;
+        });
+      return;
+    }
+
     if (state !== 'idle') return;
 
     let retryCount = 0;
@@ -118,8 +167,13 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
         })
         .catch((cause: unknown) => {
           sessionRef.current = null;
-          setState('idle');
-          setError(cause instanceof MicrophoneUnavailableError ? 'microphone' : 'failed');
+          const refused = cause instanceof MicrophoneUnavailableError;
+          // A grant withdrawn in browser settings after the fact leaves a remembered
+          // one that is no longer true, so it is dropped and asked for again rather
+          // than kept and retried against a microphone that will keep refusing.
+          if (refused) forgetMicrophoneGrant();
+          setState(refused ? 'needs-permission' : 'idle');
+          setError(refused ? 'microphone' : 'failed');
           console.error('Voice search failed:', cause);
         });
     };

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -38,6 +38,13 @@ export type VoiceSearchState =
   | 'working';
 
 /**
+ * Given to every telling of a refused microphone, so that pressing again replaces the
+ * one already up rather than stacking another behind it. Its own id and no wider, so
+ * anything else with something to say still gets said.
+ */
+const BLOCKED_TOAST_ID = 'voice-microphone-blocked';
+
+/**
  * Where each platform hides the setting. Spelled out rather than assembled from the
  * platform name so that every key can be found by searching for it.
  */
@@ -279,12 +286,13 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     if (error === 'blocked') {
       // Kept until dismissed: steps that fade before they are read are no steps at
       // all, and there is nothing to retry in the meantime.
-      const shown = toast.error(i18n.t('notifications:voiceMicrophoneBlocked'), {
+      toast.error(i18n.t('notifications:voiceMicrophoneBlocked'), {
+        id: BLOCKED_TOAST_ID,
         description: i18n.t(RESET_HINTS[getMicrophoneResetPlatform()]),
         duration: Infinity,
         action: {
           label: i18n.t('notifications:voiceMicrophoneBlockedDismiss'),
-          onClick: () => toast.dismiss(shown),
+          onClick: () => toast.dismiss(BLOCKED_TOAST_ID),
         },
       });
     } else if (error === 'microphone') {

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -45,6 +45,14 @@ export type VoiceSearchState =
 const BLOCKED_TOAST_ID = 'voice-microphone-blocked';
 
 /**
+ * Said once a session, and not once per search, which would be nagging: the reader only
+ * needs telling why the indicator is lit, not reminding of it every time they speak.
+ * Module-level so that it survives moving between pages, and resets on a reload, which
+ * is also what clears the indicator.
+ */
+let lingeringIndicatorExplained = false;
+
+/**
  * Where each platform hides the setting. Spelled out rather than assembled from the
  * platform name so that every key can be found by searching for it.
  */
@@ -131,6 +139,29 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
   }, []);
 
   /**
+   * Says why the microphone indicator is still lit, where it will be.
+   *
+   * WebKit never unsets its audio session after speech recognition finishes, so macOS
+   * and iOS keep showing the microphone as in use until the tab is reloaded or closed:
+   * https://bugs.webkit.org/show_bug.cgi?id=219671, open since 2020. Nothing is being
+   * recorded, but a reader has no way of knowing that, and an app that looks like it is
+   * listening after it was asked to stop is worth a sentence rather than a shrug.
+   *
+   * Every browser on iOS is WebKit, so this is not Safari's alone. The model backend
+   * closes the device properly and says nothing.
+   */
+  const explainLingeringIndicator = useCallback(() => {
+    if (lingeringIndicatorExplained) return;
+    if (resolveRecognizerKind() !== 'native') return;
+    const platform = getMicrophoneResetPlatform();
+    if (platform !== 'ios' && platform !== 'safari') return;
+    lingeringIndicatorExplained = true;
+    toast.info(i18n.t('notifications:voiceMicrophoneLingers'), {
+      description: i18n.t('notifications:voiceMicrophoneLingersDesc'),
+    });
+  }, [i18n]);
+
+  /**
    * Opens the microphone and hands back what was heard.
    *
    * Reports nothing when asked to stay quiet, which is how it is called straight after
@@ -168,6 +199,7 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
               attempt();
               return;
             }
+            explainLingeringIndicator();
             if (transcript) onTranscriptRef.current(transcript);
           })
           .catch((cause: unknown) => {
@@ -188,7 +220,7 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
 
       return attempt();
     },
-    [language]
+    [language, explainLingeringIndicator]
   );
 
   /**

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -52,6 +52,9 @@ const BLOCKED_TOAST_ID = 'voice-microphone-blocked';
  */
 let lingeringIndicatorExplained = false;
 
+/** Long enough to read two sentences without having to catch them. */
+const LINGERING_INDICATOR_TOAST_MS = 7000;
+
 /**
  * Where each platform hides the setting. Spelled out rather than assembled from the
  * platform name so that every key can be found by searching for it.
@@ -158,6 +161,9 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     lingeringIndicatorExplained = true;
     toast.info(i18n.t('notifications:voiceMicrophoneLingers'), {
       description: i18n.t('notifications:voiceMicrophoneLingersDesc'),
+      // Longer than a toast's usual few seconds: it is two sentences explaining
+      // something alarming, and the default gives barely enough time to read one.
+      duration: LINGERING_INDICATOR_TOAST_MS,
     });
   }, [i18n]);
 

--- a/frontend/src/hooks/useVoiceSearch.ts
+++ b/frontend/src/hooks/useVoiceSearch.ts
@@ -10,6 +10,7 @@ import {
 import {
   forgetMicrophoneGrant,
   isMicrophoneGranted,
+  releaseMicrophone,
   requestMicrophone,
 } from '@/services/speech/microphone-permission';
 import { onSpeechModelChanged, openVoiceSetup } from '@/services/speech/speech-manager';
@@ -55,6 +56,9 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
   // Guards against a second press asking for the microphone while the first prompt is
   // still up, which the state cannot express without misdescribing itself.
   const requestingRef = useRef(false);
+  // Held from the moment permission is granted until listening has its own hold on the
+  // device, so that it is never taken down and brought back up in between.
+  const heldStreamRef = useRef<MediaStream | null>(null);
 
   // Kept in a ref so a transcript arriving late calls the current handler rather than
   // the one that happened to be in scope when listening started.
@@ -98,6 +102,75 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     sessionRef.current.stop();
   }, []);
 
+  const releaseHeldMicrophone = useCallback(() => {
+    if (!heldStreamRef.current) return;
+    releaseMicrophone(heldStreamRef.current);
+    heldStreamRef.current = null;
+  }, []);
+
+  /**
+   * Opens the microphone and hands back what was heard.
+   *
+   * Reports nothing when asked to stay quiet, which is how it is called straight after
+   * a grant: a browser that wants the press itself will refuse that start, and saying
+   * so would be reporting our own attempt as the reader's failure. The button is left
+   * pulsing to invite the press instead.
+   *
+   * Returns whether listening began.
+   */
+  const beginListening = useCallback(
+    (quietly = false) => {
+      let retryCount = 0;
+      const MAX_RETRIES = 1;
+
+      const attempt = (): boolean => {
+        let session: RecognitionSession;
+        try {
+          session = createRecognizer(resolveRecognizerKind()).listen(language);
+        } catch (cause) {
+          setState('idle');
+          if (!quietly) setError('failed');
+          releaseHeldMicrophone();
+          console.error('Voice search could not start:', cause);
+          return false;
+        }
+
+        sessionRef.current = session;
+        setState('listening');
+
+        session.transcript
+          .then((transcript) => {
+            sessionRef.current = null;
+            setState('idle');
+            if (!transcript && retryCount < MAX_RETRIES) {
+              retryCount++;
+              attempt();
+              return;
+            }
+            releaseHeldMicrophone();
+            if (transcript) onTranscriptRef.current(transcript);
+          })
+          .catch((cause: unknown) => {
+            sessionRef.current = null;
+            releaseHeldMicrophone();
+            const refused = cause instanceof MicrophoneUnavailableError;
+            // A grant withdrawn in browser settings after the fact leaves a remembered
+            // one that is no longer true, so it is dropped and asked for again rather
+            // than kept and retried against a microphone that will keep refusing.
+            if (refused) forgetMicrophoneGrant();
+            setState(refused ? 'needs-permission' : 'idle');
+            setError(refused ? 'microphone' : 'failed');
+            console.error('Voice search failed:', cause);
+          });
+
+        return true;
+      };
+
+      return attempt();
+    },
+    [language, releaseHeldMicrophone]
+  );
+
   /**
    * Deliberately not an async function. Safari only allows a recognition that begins
    * in the click that asked for it, and an await anywhere before listening starts
@@ -114,18 +187,23 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
       return;
     }
 
-    // Asking is its own press, because it is the one thing here that has to be waited
-    // for. A recognition started in this press would run while the prompt is still up
-    // and hear nothing, which is the whole bug this avoids. The press after this one
-    // starts listening with the microphone already open.
+    // Permission is the one thing here that has to be waited for, so it is asked for
+    // on its own and listening follows it directly. The reader presses once: the
+    // prompt answers, and what they say next is already being heard.
     if (state === 'needs-permission') {
-      // The state is left alone while the prompt is up: "working" would say the words
-      // are being made out, which is not what is happening. A second press would only
-      // ask twice, so it is dropped instead.
+      // A second press while the prompt is up would only ask twice, so it is dropped.
+      // The state is left alone meanwhile: "working" would say the words are being
+      // made out, which is not what is happening.
       if (requestingRef.current) return;
       requestingRef.current = true;
       void requestMicrophone()
-        .then(() => setState('idle'))
+        .then((stream) => {
+          heldStreamRef.current = stream;
+          // Quietly, because a browser that insists on the press itself will refuse
+          // this and that is not a failure worth reporting: it leaves the button idle
+          // and pulsing, which asks for the press it wants.
+          if (!beginListening(true)) releaseHeldMicrophone();
+        })
         .catch((cause: unknown) => {
           setError('microphone');
           console.error('The microphone was not allowed:', cause);
@@ -138,49 +216,8 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
 
     if (state !== 'idle') return;
 
-    let retryCount = 0;
-    const MAX_RETRIES = 1;
-
-    const attempt = () => {
-      let session: RecognitionSession;
-      try {
-        session = createRecognizer(resolveRecognizerKind()).listen(language);
-      } catch (cause) {
-        setState('idle');
-        setError('failed');
-        console.error('Voice search could not start:', cause);
-        return;
-      }
-
-      sessionRef.current = session;
-      setState('listening');
-
-      session.transcript
-        .then((transcript) => {
-          sessionRef.current = null;
-          setState('idle');
-          if (!transcript && retryCount < MAX_RETRIES) {
-            retryCount++;
-            attempt();
-            return;
-          }
-          if (transcript) onTranscriptRef.current(transcript);
-        })
-        .catch((cause: unknown) => {
-          sessionRef.current = null;
-          const refused = cause instanceof MicrophoneUnavailableError;
-          // A grant withdrawn in browser settings after the fact leaves a remembered
-          // one that is no longer true, so it is dropped and asked for again rather
-          // than kept and retried against a microphone that will keep refusing.
-          if (refused) forgetMicrophoneGrant();
-          setState(refused ? 'needs-permission' : 'idle');
-          setError(refused ? 'microphone' : 'failed');
-          console.error('Voice search failed:', cause);
-        });
-    };
-
-    attempt();
-  }, [language, state]);
+    beginListening();
+  }, [beginListening, releaseHeldMicrophone, state]);
 
   // A microphone left open when the page moves on would keep recording, so any session
   // still running is abandoned on the way out.
@@ -188,6 +225,8 @@ export function useVoiceSearch({ onTranscript }: UseVoiceSearchOptions) {
     () => () => {
       sessionRef.current?.abort();
       sessionRef.current = null;
+      if (heldStreamRef.current) releaseMicrophone(heldStreamRef.current);
+      heldStreamRef.current = null;
     },
     []
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -154,14 +154,15 @@
     box-shadow: 0 0 0 1px hsl(var(--ring));
   }
 
+  /*
+   * Kept neutral whatever the field is doing. These dividers only separate the
+   * buttons from the text, and following the focus colour lit up two lines inside a
+   * field that was already outlined and glowing, which read as three things being
+   * highlighted rather than one.
+   */
   .form-field-shell__trailing {
-    border-left-color: var(--field-border);
-    transition: border-color 150ms ease-out, background-color 150ms ease-out;
-  }
-
-  /* Disabled means the button can't act on the focus, so its divider stays neutral. */
-  .form-field-shell__trailing:disabled {
     border-left-color: hsl(var(--input));
+    transition: background-color 150ms ease-out;
   }
 
   .form-field-shell__clear {

--- a/frontend/src/locales/de/common.json
+++ b/frontend/src/locales/de/common.json
@@ -235,7 +235,6 @@
     "heading": "Per Sprache suchen",
     "hint": "Einmal herunterladen ({{size}} MB), um per Sprache auf deinem Gerät zu suchen.",
     "hintReady": "Löschen, um {{size}} MB freizugeben. Die Sprachsuche funktioniert erst wieder nach einem erneuten Download.",
-    "hintNative": "Dein Browser erkennt Sprache selbst, es muss nichts heruntergeladen werden.",
     "download": "Sprachsuche herunterladen",
     "cancel": "Download abbrechen ({{percent}}%)",
     "delete": "Sprachsuche löschen",

--- a/frontend/src/locales/de/common.json
+++ b/frontend/src/locales/de/common.json
@@ -245,6 +245,7 @@
     "start": "Per Sprache suchen",
     "stop": "Aufnahme beenden",
     "working": "Das Gesagte wird ausgewertet",
-    "setUp": "Sprachsuche einrichten"
+    "setUp": "Sprachsuche einrichten",
+    "allowMicrophone": "Mikrofon erlauben"
   }
 }

--- a/frontend/src/locales/de/common.json
+++ b/frontend/src/locales/de/common.json
@@ -17,6 +17,14 @@
     "search": "Suchen",
     "clearAriaLabel": "Suche löschen"
   },
+  "searchHistory": {
+    "heading": "Letzte Suchen",
+    "clear": "Löschen",
+    "clearTitle": "Letzte Suchen löschen?",
+    "clearBody": "Die letzten Suchen und die dazu gespeicherten Ergebnisse werden entfernt, sodass eine erneute Suche eine Verbindung braucht. Das kann nicht widerrufen werden.",
+    "clearConfirm": "Löschen",
+    "cancel": "Abbrechen"
+  },
   "searchResults": {
     "noResults": "Keine Ergebnisse gefunden.",
     "artists": "Künstler",

--- a/frontend/src/locales/de/common.json
+++ b/frontend/src/locales/de/common.json
@@ -246,6 +246,7 @@
     "stop": "Aufnahme beenden",
     "working": "Das Gesagte wird ausgewertet",
     "setUp": "Sprachsuche einrichten",
-    "allowMicrophone": "Mikrofon erlauben"
+    "allowMicrophone": "Mikrofon erlauben",
+    "blocked": "Mikrofon blockiert"
   }
 }

--- a/frontend/src/locales/de/notifications.json
+++ b/frontend/src/locales/de/notifications.json
@@ -39,5 +39,13 @@
   "voiceMicrophoneDenied": "Mikrofon nicht erlaubt",
   "voiceMicrophoneDeniedDesc": "Erlaube den Zugriff auf das Mikrofon in den Browsereinstellungen, um per Sprache zu suchen.",
   "voiceSearchFailed": "Sprachsuche fehlgeschlagen",
-  "voiceSearchFailedDesc": "Beim Zuhören ist etwas schiefgegangen. Bitte versuche es erneut."
+  "voiceSearchFailedDesc": "Beim Zuhören ist etwas schiefgegangen. Bitte versuche es erneut.",
+  "voiceMicrophoneBlocked": "Mikrofon blockiert",
+  "voiceMicrophoneBlockedIos": "Tippe auf aA in der Adressleiste, wähle Website-Einstellungen, setze Mikrofon auf Erlauben und lade die Seite neu.",
+  "voiceMicrophoneBlockedSafari": "Öffne Safari, wähle Einstellungen für diese Website, setze Mikrofon auf Erlauben und lade die Seite neu.",
+  "voiceMicrophoneBlockedAndroid": "Tippe auf das Schloss in der Adressleiste, öffne Berechtigungen, setze Mikrofon auf Erlauben und lade die Seite neu.",
+  "voiceMicrophoneBlockedChrome": "Klicke auf das Schloss in der Adressleiste, setze Mikrofon auf Erlauben und lade die Seite neu.",
+  "voiceMicrophoneBlockedFirefox": "Klicke auf das Schloss in der Adressleiste, hebe die Mikrofon-Blockierung auf und lade die Seite neu.",
+  "voiceMicrophoneBlockedGeneric": "Erlaube das Mikrofon für diese Seite in den Browsereinstellungen und lade die Seite neu.",
+  "voiceMicrophoneBlockedDismiss": "Verstanden"
 }

--- a/frontend/src/locales/de/notifications.json
+++ b/frontend/src/locales/de/notifications.json
@@ -49,5 +49,7 @@
   "voiceMicrophoneBlockedGeneric": "Erlaube das Mikrofon für diese Seite in den Browsereinstellungen und lade die Seite neu.",
   "voiceMicrophoneBlockedDismiss": "Verstanden",
   "voiceMicrophoneReady": "Mikrofon bereit",
-  "voiceMicrophoneReadyDesc": "Tippe auf das Mikrofon, um zu sprechen."
+  "voiceMicrophoneReadyDesc": "Tippe auf das Mikrofon, um zu sprechen.",
+  "voiceMicrophoneLingers": "Safari lässt die Mikrofonanzeige an",
+  "voiceMicrophoneLingersDesc": "Es wird nichts aufgenommen. Das ist ein Safari-Fehler, und die Anzeige verschwindet, wenn du neu lädst oder den Tab schließt."
 }

--- a/frontend/src/locales/de/notifications.json
+++ b/frontend/src/locales/de/notifications.json
@@ -35,5 +35,9 @@
   "jamSessionJoinFailed": "Beitritt zur Jam-Session fehlgeschlagen. Bitte prüfe den Verbindungscode und versuche es erneut.",
   "jamSessionInvalidString": "Ungültiger Verbindungscode",
   "connectionStringCopied": "Verbindungscode in die Zwischenablage kopiert!",
-  "cameraError": "Kein Zugriff auf die Kamera. Bitte prüfe die Berechtigungen."
+  "cameraError": "Kein Zugriff auf die Kamera. Bitte prüfe die Berechtigungen.",
+  "voiceMicrophoneDenied": "Mikrofon nicht erlaubt",
+  "voiceMicrophoneDeniedDesc": "Erlaube den Zugriff auf das Mikrofon in den Browsereinstellungen, um per Sprache zu suchen.",
+  "voiceSearchFailed": "Sprachsuche fehlgeschlagen",
+  "voiceSearchFailedDesc": "Beim Zuhören ist etwas schiefgegangen. Bitte versuche es erneut."
 }

--- a/frontend/src/locales/de/notifications.json
+++ b/frontend/src/locales/de/notifications.json
@@ -47,5 +47,7 @@
   "voiceMicrophoneBlockedChrome": "Klicke auf das Schloss in der Adressleiste, setze Mikrofon auf Erlauben und lade die Seite neu.",
   "voiceMicrophoneBlockedFirefox": "Klicke auf das Schloss in der Adressleiste, hebe die Mikrofon-Blockierung auf und lade die Seite neu.",
   "voiceMicrophoneBlockedGeneric": "Erlaube das Mikrofon für diese Seite in den Browsereinstellungen und lade die Seite neu.",
-  "voiceMicrophoneBlockedDismiss": "Verstanden"
+  "voiceMicrophoneBlockedDismiss": "Verstanden",
+  "voiceMicrophoneReady": "Mikrofon bereit",
+  "voiceMicrophoneReadyDesc": "Tippe auf das Mikrofon, um zu sprechen."
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -17,6 +17,14 @@
     "search": "Search",
     "clearAriaLabel": "Clear search"
   },
+  "searchHistory": {
+    "heading": "Recent searches",
+    "clear": "Clear",
+    "clearTitle": "Clear recent searches?",
+    "clearBody": "Recent searches and the results saved with them are removed, so searching for them again needs a connection. This cannot be undone.",
+    "clearConfirm": "Clear",
+    "cancel": "Cancel"
+  },
   "searchResults": {
     "noResults": "No results were found.",
     "artists": "Artists",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -235,7 +235,6 @@
     "heading": "Search by voice",
     "hint": "Download once ({{size}} MB) to search by speaking, on your device.",
     "hintReady": "Delete to free up {{size}} MB. Searching by voice stops working until you download it again.",
-    "hintNative": "Your browser recognises speech itself, so nothing needs downloading.",
     "download": "Download voice search",
     "cancel": "Cancel download ({{percent}}%)",
     "delete": "Delete voice search",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -246,6 +246,7 @@
     "stop": "Stop listening",
     "working": "Working out what you said",
     "setUp": "Set up voice search",
-    "allowMicrophone": "Allow the microphone"
+    "allowMicrophone": "Allow the microphone",
+    "blocked": "Microphone blocked"
   }
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -245,6 +245,7 @@
     "start": "Search by voice",
     "stop": "Stop listening",
     "working": "Working out what you said",
-    "setUp": "Set up voice search"
+    "setUp": "Set up voice search",
+    "allowMicrophone": "Allow the microphone"
   }
 }

--- a/frontend/src/locales/en/notifications.json
+++ b/frontend/src/locales/en/notifications.json
@@ -39,5 +39,13 @@
   "voiceMicrophoneDenied": "Microphone not allowed",
   "voiceMicrophoneDeniedDesc": "Allow access to the microphone in your browser settings to search by voice.",
   "voiceSearchFailed": "Voice search failed",
-  "voiceSearchFailedDesc": "Something went wrong while listening. Please try again."
+  "voiceSearchFailedDesc": "Something went wrong while listening. Please try again.",
+  "voiceMicrophoneBlocked": "Microphone blocked",
+  "voiceMicrophoneBlockedIos": "Tap aA in the address bar, choose Website Settings, set Microphone to Allow, then reload the page.",
+  "voiceMicrophoneBlockedSafari": "Open Safari, choose Settings for This Website, set Microphone to Allow, then reload the page.",
+  "voiceMicrophoneBlockedAndroid": "Tap the padlock in the address bar, open Permissions, set Microphone to Allow, then reload the page.",
+  "voiceMicrophoneBlockedChrome": "Click the padlock in the address bar, set Microphone to Allow, then reload the page.",
+  "voiceMicrophoneBlockedFirefox": "Click the padlock in the address bar, remove the microphone block, then reload the page.",
+  "voiceMicrophoneBlockedGeneric": "Allow the microphone for this site in your browser settings, then reload the page.",
+  "voiceMicrophoneBlockedDismiss": "Got it"
 }

--- a/frontend/src/locales/en/notifications.json
+++ b/frontend/src/locales/en/notifications.json
@@ -35,5 +35,9 @@
   "jamSessionJoinFailed": "Failed to join the jam session. Please check the connection string and try again.",
   "jamSessionInvalidString": "Invalid connection string",
   "connectionStringCopied": "Connection string copied to clipboard!",
-  "cameraError": "Could not access camera. Please check permissions."
+  "cameraError": "Could not access camera. Please check permissions.",
+  "voiceMicrophoneDenied": "Microphone not allowed",
+  "voiceMicrophoneDeniedDesc": "Allow access to the microphone in your browser settings to search by voice.",
+  "voiceSearchFailed": "Voice search failed",
+  "voiceSearchFailedDesc": "Something went wrong while listening. Please try again."
 }

--- a/frontend/src/locales/en/notifications.json
+++ b/frontend/src/locales/en/notifications.json
@@ -47,5 +47,7 @@
   "voiceMicrophoneBlockedChrome": "Click the padlock in the address bar, set Microphone to Allow, then reload the page.",
   "voiceMicrophoneBlockedFirefox": "Click the padlock in the address bar, remove the microphone block, then reload the page.",
   "voiceMicrophoneBlockedGeneric": "Allow the microphone for this site in your browser settings, then reload the page.",
-  "voiceMicrophoneBlockedDismiss": "Got it"
+  "voiceMicrophoneBlockedDismiss": "Got it",
+  "voiceMicrophoneReady": "Microphone ready",
+  "voiceMicrophoneReadyDesc": "Tap the microphone to speak."
 }

--- a/frontend/src/locales/en/notifications.json
+++ b/frontend/src/locales/en/notifications.json
@@ -49,5 +49,7 @@
   "voiceMicrophoneBlockedGeneric": "Allow the microphone for this site in your browser settings, then reload the page.",
   "voiceMicrophoneBlockedDismiss": "Got it",
   "voiceMicrophoneReady": "Microphone ready",
-  "voiceMicrophoneReadyDesc": "Tap the microphone to speak."
+  "voiceMicrophoneReadyDesc": "Tap the microphone to speak.",
+  "voiceMicrophoneLingers": "Safari leaves the microphone indicator on",
+  "voiceMicrophoneLingersDesc": "Nothing is being recorded. It is a Safari bug, and the indicator clears when you reload or close the tab."
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -17,6 +17,14 @@
     "search": "Buscar",
     "clearAriaLabel": "Limpiar búsqueda"
   },
+  "searchHistory": {
+    "heading": "Búsquedas recientes",
+    "clear": "Borrar",
+    "clearTitle": "¿Borrar las búsquedas recientes?",
+    "clearBody": "Se eliminarán las búsquedas recientes y los resultados guardados con ellas, así que buscarlas de nuevo necesitará conexión. Esto no se puede deshacer.",
+    "clearConfirm": "Borrar",
+    "cancel": "Cancelar"
+  },
   "searchResults": {
     "noResults": "No se encontraron resultados.",
     "artists": "Artistas",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -235,7 +235,6 @@
     "heading": "Buscar por voz",
     "hint": "Descarga una vez ({{size}} MB) para buscar hablando, en tu dispositivo.",
     "hintReady": "Elimínalo para liberar {{size}} MB. La búsqueda por voz dejará de funcionar hasta que lo descargues de nuevo.",
-    "hintNative": "Tu navegador reconoce la voz por su cuenta, así que no hace falta descargar nada.",
     "download": "Descargar búsqueda por voz",
     "cancel": "Cancelar descarga ({{percent}}%)",
     "delete": "Eliminar búsqueda por voz",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -245,6 +245,7 @@
     "start": "Buscar por voz",
     "stop": "Dejar de escuchar",
     "working": "Interpretando lo que dijiste",
-    "setUp": "Activar la búsqueda por voz"
+    "setUp": "Activar la búsqueda por voz",
+    "allowMicrophone": "Permitir el micrófono"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -246,6 +246,7 @@
     "stop": "Dejar de escuchar",
     "working": "Interpretando lo que dijiste",
     "setUp": "Activar la búsqueda por voz",
-    "allowMicrophone": "Permitir el micrófono"
+    "allowMicrophone": "Permitir el micrófono",
+    "blocked": "Micrófono bloqueado"
   }
 }

--- a/frontend/src/locales/es/notifications.json
+++ b/frontend/src/locales/es/notifications.json
@@ -47,5 +47,7 @@
   "voiceMicrophoneBlockedChrome": "Haz clic en el candado en la barra de direcciones, pon Micrófono en Permitir y recarga la página.",
   "voiceMicrophoneBlockedFirefox": "Haz clic en el candado en la barra de direcciones, quita el bloqueo del micrófono y recarga la página.",
   "voiceMicrophoneBlockedGeneric": "Permite el micrófono para este sitio en la configuración del navegador y recarga la página.",
-  "voiceMicrophoneBlockedDismiss": "Entendido"
+  "voiceMicrophoneBlockedDismiss": "Entendido",
+  "voiceMicrophoneReady": "Micrófono listo",
+  "voiceMicrophoneReadyDesc": "Toca el micrófono para hablar."
 }

--- a/frontend/src/locales/es/notifications.json
+++ b/frontend/src/locales/es/notifications.json
@@ -35,5 +35,9 @@
   "jamSessionJoinFailed": "No se pudo unir a la sesión. Verifica la cadena de conexión e inténtalo de nuevo.",
   "jamSessionInvalidString": "Cadena de conexión no válida",
   "connectionStringCopied": "¡Cadena de conexión copiada al portapapeles!",
-  "cameraError": "No se pudo acceder a la cámara. Por favor, verifica los permisos."
+  "cameraError": "No se pudo acceder a la cámara. Por favor, verifica los permisos.",
+  "voiceMicrophoneDenied": "Micrófono no permitido",
+  "voiceMicrophoneDeniedDesc": "Permite el acceso al micrófono en la configuración del navegador para buscar por voz.",
+  "voiceSearchFailed": "Error en la búsqueda por voz",
+  "voiceSearchFailedDesc": "Algo salió mal al escuchar. Por favor, inténtalo de nuevo."
 }

--- a/frontend/src/locales/es/notifications.json
+++ b/frontend/src/locales/es/notifications.json
@@ -49,5 +49,7 @@
   "voiceMicrophoneBlockedGeneric": "Permite el micrófono para este sitio en la configuración del navegador y recarga la página.",
   "voiceMicrophoneBlockedDismiss": "Entendido",
   "voiceMicrophoneReady": "Micrófono listo",
-  "voiceMicrophoneReadyDesc": "Toca el micrófono para hablar."
+  "voiceMicrophoneReadyDesc": "Toca el micrófono para hablar.",
+  "voiceMicrophoneLingers": "Safari deja encendido el indicador del micrófono",
+  "voiceMicrophoneLingersDesc": "No se está grabando nada. Es un error de Safari, y el indicador desaparece al recargar o cerrar la pestaña."
 }

--- a/frontend/src/locales/es/notifications.json
+++ b/frontend/src/locales/es/notifications.json
@@ -39,5 +39,13 @@
   "voiceMicrophoneDenied": "Micrófono no permitido",
   "voiceMicrophoneDeniedDesc": "Permite el acceso al micrófono en la configuración del navegador para buscar por voz.",
   "voiceSearchFailed": "Error en la búsqueda por voz",
-  "voiceSearchFailedDesc": "Algo salió mal al escuchar. Por favor, inténtalo de nuevo."
+  "voiceSearchFailedDesc": "Algo salió mal al escuchar. Por favor, inténtalo de nuevo.",
+  "voiceMicrophoneBlocked": "Micrófono bloqueado",
+  "voiceMicrophoneBlockedIos": "Toca aA en la barra de direcciones, elige Ajustes del sitio web, pon Micrófono en Permitir y recarga la página.",
+  "voiceMicrophoneBlockedSafari": "Abre Safari, elige Ajustes para esta web, pon Micrófono en Permitir y recarga la página.",
+  "voiceMicrophoneBlockedAndroid": "Toca el candado en la barra de direcciones, abre Permisos, pon Micrófono en Permitir y recarga la página.",
+  "voiceMicrophoneBlockedChrome": "Haz clic en el candado en la barra de direcciones, pon Micrófono en Permitir y recarga la página.",
+  "voiceMicrophoneBlockedFirefox": "Haz clic en el candado en la barra de direcciones, quita el bloqueo del micrófono y recarga la página.",
+  "voiceMicrophoneBlockedGeneric": "Permite el micrófono para este sitio en la configuración del navegador y recarga la página.",
+  "voiceMicrophoneBlockedDismiss": "Entendido"
 }

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -246,6 +246,7 @@
     "stop": "Parar de ouvir",
     "working": "Interpretando o que você disse",
     "setUp": "Ativar a pesquisa por voz",
-    "allowMicrophone": "Permitir o microfone"
+    "allowMicrophone": "Permitir o microfone",
+    "blocked": "Microfone bloqueado"
   }
 }

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -245,6 +245,7 @@
     "start": "Pesquisar por voz",
     "stop": "Parar de ouvir",
     "working": "Interpretando o que você disse",
-    "setUp": "Ativar a pesquisa por voz"
+    "setUp": "Ativar a pesquisa por voz",
+    "allowMicrophone": "Permitir o microfone"
   }
 }

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -17,6 +17,14 @@
     "search": "Pesquisar",
     "clearAriaLabel": "Limpar pesquisa"
   },
+  "searchHistory": {
+    "heading": "Buscas recentes",
+    "clear": "Limpar",
+    "clearTitle": "Limpar as buscas recentes?",
+    "clearBody": "As buscas recentes e os resultados salvos com elas serão removidos, então buscá-las de novo vai precisar de conexão. Isso não pode ser desfeito.",
+    "clearConfirm": "Limpar",
+    "cancel": "Cancelar"
+  },
   "searchResults": {
     "noResults": "Nenhum resultado encontrado.",
     "artists": "Artistas",

--- a/frontend/src/locales/pt-BR/common.json
+++ b/frontend/src/locales/pt-BR/common.json
@@ -235,7 +235,6 @@
     "heading": "Pesquisar por voz",
     "hint": "Baixe uma vez ({{size}} MB) para pesquisar falando, no seu dispositivo.",
     "hintReady": "Exclua para liberar {{size}} MB. A pesquisa por voz para de funcionar até você baixar novamente.",
-    "hintNative": "Seu navegador reconhece voz por conta própria, então nada precisa ser baixado.",
     "download": "Baixar pesquisa por voz",
     "cancel": "Cancelar download ({{percent}}%)",
     "delete": "Excluir pesquisa por voz",

--- a/frontend/src/locales/pt-BR/notifications.json
+++ b/frontend/src/locales/pt-BR/notifications.json
@@ -35,5 +35,9 @@
   "jamSessionJoinFailed": "Falha ao entrar na sessão. Por favor, verifique a string de conexão e tente novamente.",
   "jamSessionInvalidString": "String de conexão inválida",
   "connectionStringCopied": "String de conexão copiada para a área de transferência!",
-  "cameraError": "Não foi possível acessar a câmera. Por favor, verifique as permissões."
+  "cameraError": "Não foi possível acessar a câmera. Por favor, verifique as permissões.",
+  "voiceMicrophoneDenied": "Microfone não permitido",
+  "voiceMicrophoneDeniedDesc": "Permita o acesso ao microfone nas configurações do navegador para pesquisar por voz.",
+  "voiceSearchFailed": "Falha na pesquisa por voz",
+  "voiceSearchFailedDesc": "Algo deu errado ao ouvir. Por favor, tente novamente."
 }

--- a/frontend/src/locales/pt-BR/notifications.json
+++ b/frontend/src/locales/pt-BR/notifications.json
@@ -47,5 +47,7 @@
   "voiceMicrophoneBlockedChrome": "Clique no cadeado na barra de endereço, defina Microfone como Permitir e recarregue a página.",
   "voiceMicrophoneBlockedFirefox": "Clique no cadeado na barra de endereço, remova o bloqueio do microfone e recarregue a página.",
   "voiceMicrophoneBlockedGeneric": "Permita o microfone para este site nas configurações do navegador e recarregue a página.",
-  "voiceMicrophoneBlockedDismiss": "Entendi"
+  "voiceMicrophoneBlockedDismiss": "Entendi",
+  "voiceMicrophoneReady": "Microfone pronto",
+  "voiceMicrophoneReadyDesc": "Toque no microfone para falar."
 }

--- a/frontend/src/locales/pt-BR/notifications.json
+++ b/frontend/src/locales/pt-BR/notifications.json
@@ -49,5 +49,7 @@
   "voiceMicrophoneBlockedGeneric": "Permita o microfone para este site nas configurações do navegador e recarregue a página.",
   "voiceMicrophoneBlockedDismiss": "Entendi",
   "voiceMicrophoneReady": "Microfone pronto",
-  "voiceMicrophoneReadyDesc": "Toque no microfone para falar."
+  "voiceMicrophoneReadyDesc": "Toque no microfone para falar.",
+  "voiceMicrophoneLingers": "O Safari deixa o indicador do microfone aceso",
+  "voiceMicrophoneLingersDesc": "Nada está sendo gravado. É um bug do Safari, e o indicador desaparece ao recarregar ou fechar a aba."
 }

--- a/frontend/src/locales/pt-BR/notifications.json
+++ b/frontend/src/locales/pt-BR/notifications.json
@@ -39,5 +39,13 @@
   "voiceMicrophoneDenied": "Microfone não permitido",
   "voiceMicrophoneDeniedDesc": "Permita o acesso ao microfone nas configurações do navegador para pesquisar por voz.",
   "voiceSearchFailed": "Falha na pesquisa por voz",
-  "voiceSearchFailedDesc": "Algo deu errado ao ouvir. Por favor, tente novamente."
+  "voiceSearchFailedDesc": "Algo deu errado ao ouvir. Por favor, tente novamente.",
+  "voiceMicrophoneBlocked": "Microfone bloqueado",
+  "voiceMicrophoneBlockedIos": "Toque em aA na barra de endereço, escolha Configurações do site, defina Microfone como Permitir e recarregue a página.",
+  "voiceMicrophoneBlockedSafari": "Abra o Safari, escolha Configurações para este site, defina Microfone como Permitir e recarregue a página.",
+  "voiceMicrophoneBlockedAndroid": "Toque no cadeado na barra de endereço, abra Permissões, defina Microfone como Permitir e recarregue a página.",
+  "voiceMicrophoneBlockedChrome": "Clique no cadeado na barra de endereço, defina Microfone como Permitir e recarregue a página.",
+  "voiceMicrophoneBlockedFirefox": "Clique no cadeado na barra de endereço, remova o bloqueio do microfone e recarregue a página.",
+  "voiceMicrophoneBlockedGeneric": "Permita o microfone para este site nas configurações do navegador e recarregue a página.",
+  "voiceMicrophoneBlockedDismiss": "Entendi"
 }

--- a/frontend/src/search/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/search/components/SearchBar/SearchBar.tsx
@@ -1,7 +1,6 @@
 import { Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import FormField from "@/components/ui/form-field";
-import { Separator } from "@/components/ui/separator";
 import type { SearchBarProps } from "./SearchBar.types";
 import VoiceSearchButton from "../VoiceSearchButton/VoiceSearchButton";
 import { cyAttr } from "@/utils/test-utils";
@@ -28,43 +27,38 @@ const SearchBar = ({
 
   return (
     <form className={`w-full ${className}`} onSubmit={handleSubmit} id="search-form">
-      <div className="flex flex-col gap-2">
-        <FormField
-          id="search-input"
-          value={value}
-          onChange={onInputChange}
-          disabled={loading}
-          placeholder={t("searchBar.placeholder")}
-          trailingButton={
-            <button
-              type="submit"
-              aria-label={t("searchBar.search")}
-              disabled={loading || isSearchDisabled}
-              className="form-field-shell__trailing flex w-10 items-center justify-center border-l bg-background text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
-              {...cyAttr("search-submit-button")}
-            >
-              <Search className="h-4 w-4" />
-            </button>
-          }
-        />
-
-        {/* Back and clear moved to the results card - they act on results, not
-            the field, and that's where a reader looks for them now. Only voice
-            is still about the field itself, so it's the only thing left here. */}
-        {hasVoice && (
+      {/* Back and clear moved to the results card - they act on results, not the
+          field. Voice is about the field itself, so it sits within it, ahead of
+          submit: both are things to do with what has been typed, and keeping them
+          together is what lets the field be a single row. */}
+      <FormField
+        id="search-input"
+        value={value}
+        onChange={onInputChange}
+        disabled={loading}
+        placeholder={t("searchBar.placeholder")}
+        trailingButton={
           <>
-            <Separator className="my-2" />
-            <div className="flex items-center justify-end">
+            {hasVoice && (
               <VoiceSearchButton
                 state={voiceState}
                 onStart={onVoiceStart}
                 onStop={onVoiceStop}
                 disabled={loading}
               />
-            </div>
+            )}
+            <button
+              type="submit"
+              aria-label={t("searchBar.search")}
+              disabled={loading || isSearchDisabled}
+              className="form-field-shell__trailing flex w-10 shrink-0 items-center justify-center border-l bg-background text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+              {...cyAttr("search-submit-button")}
+            >
+              <Search className="h-4 w-4" />
+            </button>
           </>
-        )}
-      </div>
+        }
+      />
     </form>
   );
 };

--- a/frontend/src/search/components/SearchHistory/SearchHistory.tsx
+++ b/frontend/src/search/components/SearchHistory/SearchHistory.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { Clock, User, Search, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,8 +12,17 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 import { searchCacheService } from "@/storage/services/search-cache/search-cache-service";
 import type { SearchHistoryEntry } from "@/search/hooks/useSearchHistory";
 
@@ -22,41 +33,87 @@ interface SearchHistoryProps {
 }
 
 const SearchHistory: React.FC<SearchHistoryProps> = ({ history, onSelect, onClear }) => {
+  const { t } = useTranslation();
+  const isMobile = useIsMobile();
+  const [confirming, setConfirming] = useState(false);
+
   if (history.length === 0) return null;
 
   async function handleConfirmClear() {
     await searchCacheService.clear();
+    setConfirming(false);
     onClear();
   }
+
+  const title = t("searchHistory.clearTitle");
+  // Says what actually goes. The list is drawn from the cached searches themselves,
+  // so clearing it takes their saved results with it: the next search of something
+  // searched before has to be fetched again, and cannot be had offline at all.
+  const body = t("searchHistory.clearBody");
 
   return (
     <div className="w-full max-w-3xl mx-auto">
       <div className="flex items-center justify-between px-1 mb-2">
         <p className="text-xs text-muted-foreground flex items-center gap-1 leading-7">
           <Clock className="h-3 w-3" />
-          Recent searches
+          {t("searchHistory.heading")}
         </p>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <button className="group text-xs text-muted-foreground flex items-center gap-1 transition-colors hover:bg-transparent focus:outline-none">
-              <Trash2 className="h-3 w-3 text-destructive/50 group-hover:text-destructive transition-colors" />
-              Clear
-            </button>
-          </AlertDialogTrigger>
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="group text-xs text-muted-foreground flex items-center gap-1 transition-colors hover:bg-transparent focus:outline-none"
+        >
+          <Trash2 className="h-3 w-3 text-destructive/50 group-hover:text-destructive transition-colors" />
+          {t("searchHistory.clear")}
+        </button>
+      </div>
+
+      {/* A sheet on phones, where it rises next to the thumb and can use the full
+          width, as the language panel does. On larger screens a dialog instead: this
+          is a decision that cannot be undone, so it wants the focus trap and the
+          dimmed page behind it that a dialog brings and a sheet does not. */}
+      {isMobile ? (
+        <Sheet open={confirming} onOpenChange={setConfirming}>
+          <SheetContent
+            side="bottom"
+            className="gap-0 rounded-t-xl pb-[max(1rem,env(safe-area-inset-bottom))]"
+          >
+            <SheetHeader className="text-left">
+              <SheetTitle>{title}</SheetTitle>
+              <SheetDescription>{body}</SheetDescription>
+            </SheetHeader>
+            {/* Stacked, with the destructive one first: it is what the reader came
+                for, and on a phone the lowest button is the easiest to hit. */}
+            <SheetFooter className="mt-4 flex-col gap-2 sm:flex-col sm:space-x-0">
+              <Button variant="outline" onClick={() => setConfirming(false)}>
+                {t("searchHistory.cancel")}
+              </Button>
+              <Button variant="destructive" onClick={handleConfirmClear}>
+                {t("searchHistory.clearConfirm")}
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <AlertDialog open={confirming} onOpenChange={setConfirming}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Clear recent searches?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will remove all recent search history. This action cannot be undone.
-              </AlertDialogDescription>
+              <AlertDialogTitle>{title}</AlertDialogTitle>
+              <AlertDialogDescription>{body}</AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={handleConfirmClear}>Clear</AlertDialogAction>
+              <AlertDialogCancel>{t("searchHistory.cancel")}</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleConfirmClear}
+                className={cn(buttonVariants({ variant: "destructive" }))}
+              >
+                {t("searchHistory.clearConfirm")}
+              </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
-      </div>
+      )}
+
       <div className="grid grid-cols-1 gap-y-2">
         {history.map((entry) => {
           // An artist opened from results is shown under their real name; a search

--- a/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
+++ b/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
@@ -30,6 +30,7 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   const working = state === "working";
   const needsSetup = state === "needs-setup";
   const needsPermission = state === "needs-permission";
+  const blocked = state === "blocked";
 
   /**
    * Pulsed once the microphone has just been allowed, because the press that allowed
@@ -59,6 +60,7 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   const label = (() => {
     if (needsSetup) return t("voiceSearch.setUp");
     if (needsPermission) return t("voiceSearch.allowMicrophone");
+    if (blocked) return t("voiceSearch.blocked");
     if (listening) return t("voiceSearch.stop");
     if (working) return t("voiceSearch.working");
     return t("voiceSearch.start");
@@ -78,7 +80,7 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
         "form-field-shell__trailing relative flex w-10 shrink-0 items-center justify-center border-l bg-background hover:bg-accent disabled:pointer-events-none disabled:opacity-50",
         listening
           ? "text-destructive"
-          : needsSetup || needsPermission
+          : needsSetup || needsPermission || blocked
             ? "text-muted-foreground"
             : "text-foreground"
       )}

--- a/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
+++ b/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import { Loader2, Mic, Square } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -11,9 +10,6 @@ interface VoiceSearchButtonProps {
   onStop: () => void;
   disabled?: boolean;
 }
-
-/** Two pulses: the ping cycle is a second, and longer than that starts to nag. */
-const JUST_ALLOWED_MS = 2000;
 
 /**
  * Asks for a spoken search, as a segment of the search field itself sitting ahead of
@@ -31,31 +27,6 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   const needsSetup = state === "needs-setup";
   const needsPermission = state === "needs-permission";
   const blocked = state === "blocked";
-
-  /**
-   * Pulsed once the microphone has just been allowed, because the press that allowed
-   * it was not the press that listens: attention is on the system prompt at that
-   * moment, and the icon settling from muted to ordinary is easy to return to and
-   * miss. It says the next press is the one that hears you.
-   */
-  const [justAllowed, setJustAllowed] = useState(false);
-  const previousState = useRef(state);
-  useEffect(() => {
-    const wasAwaitingPermission = previousState.current === "needs-permission";
-    previousState.current = state;
-    if (wasAwaitingPermission && state === "idle") setJustAllowed(true);
-    // Pressing it is the point of the hint, so anything but waiting to be pressed
-    // ends it early.
-    else if (state !== "idle") setJustAllowed(false);
-  }, [state]);
-
-  // Timed against the hint rather than the state, so that pressing record while it
-  // pulses does not cancel the timer and strand the pulse on forever.
-  useEffect(() => {
-    if (!justAllowed) return;
-    const settle = setTimeout(() => setJustAllowed(false), JUST_ALLOWED_MS);
-    return () => clearTimeout(settle);
-  }, [justAllowed]);
 
   const label = (() => {
     if (needsSetup) return t("voiceSearch.setUp");
@@ -95,23 +66,22 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
       ) : (
         <Mic className="h-4 w-4" />
       )}
-      {(listening || justAllowed) && (
+      {listening && (
         <span
           aria-hidden
-          className={cn(
-            // Inset rather than centred by a translate, because ping animates the
-            // transform: a translate here would be dropped the moment it began and
-            // the ring would expand from the corner.
-            //
-            // Inset by a quarter of the segment leaves a ring half its width, so that
-            // ping doubling it lands exactly on the segment's own bounds. The field
-            // clips whatever leaves it, so a wider ring would expand into a straight
-            // edge.
-            "absolute inset-2.5 animate-ping rounded-full border motion-reduce:animate-none",
-            // Red says recording. Being ready is not an alarm, so it borrows the
-            // ordinary accent instead.
-            listening ? "border-destructive" : "border-primary"
-          )}
+          // Kept for recording alone. It once said "ready" too, in another colour, but
+          // a ring pulsing beside a microphone reads as live whatever colour it is,
+          // and saying "ready" and "recording" the same way left a reader who did not
+          // already know the app unable to tell which was which. Being ready is said
+          // in words now.
+          //
+          // Inset rather than centred by a translate, because ping animates the
+          // transform: a translate here would be dropped the moment it began and the
+          // ring would expand from the corner. Inset by a quarter of the segment
+          // leaves a ring half its width, so that ping doubling it lands exactly on
+          // the segment's own bounds; the field clips whatever leaves it, so a wider
+          // ring would expand into a straight edge.
+          className="absolute inset-2.5 animate-ping rounded-full border border-destructive motion-reduce:animate-none"
         />
       )}
     </button>

--- a/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
+++ b/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
@@ -23,9 +23,11 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   const listening = state === "listening";
   const working = state === "working";
   const needsSetup = state === "needs-setup";
+  const needsPermission = state === "needs-permission";
 
   const label = (() => {
     if (needsSetup) return t("voiceSearch.setUp");
+    if (needsPermission) return t("voiceSearch.allowMicrophone");
     if (listening) return t("voiceSearch.stop");
     if (working) return t("voiceSearch.working");
     return t("voiceSearch.start");
@@ -39,7 +41,9 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
       className={cn(
         "relative h-10 w-10 rounded-full",
         listening && "border-destructive text-destructive",
-        needsSetup && "border-dashed text-muted-foreground"
+        // Dashed for both, because both mean the press opens a step of its own rather
+        // than the microphone.
+        (needsSetup || needsPermission) && "border-dashed text-muted-foreground"
       )}
       // Pressed again to finish speaking, which is how a reader says they are done
       // rather than waiting out the cap.

--- a/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
+++ b/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { Loader2, Mic, Square } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -12,6 +13,9 @@ interface VoiceSearchButtonProps {
   disabled?: boolean;
 }
 
+/** Two pulses: the ping cycle is a second, and longer than that starts to nag. */
+const JUST_ALLOWED_MS = 2000;
+
 /**
  * Asks for a spoken search. Its look says what pressing it will do: dashed while
  * something still has to be downloaded, since that press opens the offer rather
@@ -24,6 +28,23 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   const working = state === "working";
   const needsSetup = state === "needs-setup";
   const needsPermission = state === "needs-permission";
+
+  /**
+   * Pulsed once the microphone has just been allowed, because the press that allowed
+   * it was not the press that listens: attention is on the system prompt at that
+   * moment, and the button going quietly from dashed to solid is easy to return to
+   * and miss. It says the next press is the one that hears you.
+   */
+  const [justAllowed, setJustAllowed] = useState(false);
+  const previousState = useRef(state);
+  useEffect(() => {
+    const wasAwaitingPermission = previousState.current === "needs-permission";
+    previousState.current = state;
+    if (!wasAwaitingPermission || state !== "idle") return;
+    setJustAllowed(true);
+    const settle = setTimeout(() => setJustAllowed(false), JUST_ALLOWED_MS);
+    return () => clearTimeout(settle);
+  }, [state]);
 
   const label = (() => {
     if (needsSetup) return t("voiceSearch.setUp");
@@ -62,10 +83,17 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
       ) : (
         <Mic className="h-4 w-4" />
       )}
-      {listening && (
+      {(listening || justAllowed) && (
         <span
           aria-hidden
-          className="absolute inset-0 animate-ping rounded-full border border-destructive"
+          className={cn(
+            // Decorative, and the state is already carried by the icon and the border,
+            // so a reader who asked for less movement loses nothing by it stopping.
+            "absolute inset-0 animate-ping rounded-full border motion-reduce:animate-none",
+            // Red says recording. Being ready is not an alarm, so it borrows the
+            // ordinary accent instead.
+            listening ? "border-destructive" : "border-primary"
+          )}
         />
       )}
     </Button>

--- a/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
+++ b/frontend/src/search/components/VoiceSearchButton/VoiceSearchButton.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Loader2, Mic, Square } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { VoiceSearchState } from "@/hooks/useVoiceSearch";
 import { cyAttr } from "@/utils/test-utils";
@@ -17,9 +16,12 @@ interface VoiceSearchButtonProps {
 const JUST_ALLOWED_MS = 2000;
 
 /**
- * Asks for a spoken search. Its look says what pressing it will do: dashed while
- * something still has to be downloaded, since that press opens the offer rather
- * than the microphone.
+ * Asks for a spoken search, as a segment of the search field itself sitting ahead of
+ * submit. It carries the same divider as submit does, so the two read as a pair of
+ * things to do with what has been typed rather than one button and one loose icon.
+ *
+ * Its own state is left to colour and to the icon: muted while a press would open a
+ * step of its own rather than the microphone, and red once it is recording.
  */
 const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButtonProps) => {
   const { t } = useTranslation();
@@ -32,19 +34,27 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   /**
    * Pulsed once the microphone has just been allowed, because the press that allowed
    * it was not the press that listens: attention is on the system prompt at that
-   * moment, and the button going quietly from dashed to solid is easy to return to
-   * and miss. It says the next press is the one that hears you.
+   * moment, and the icon settling from muted to ordinary is easy to return to and
+   * miss. It says the next press is the one that hears you.
    */
   const [justAllowed, setJustAllowed] = useState(false);
   const previousState = useRef(state);
   useEffect(() => {
     const wasAwaitingPermission = previousState.current === "needs-permission";
     previousState.current = state;
-    if (!wasAwaitingPermission || state !== "idle") return;
-    setJustAllowed(true);
+    if (wasAwaitingPermission && state === "idle") setJustAllowed(true);
+    // Pressing it is the point of the hint, so anything but waiting to be pressed
+    // ends it early.
+    else if (state !== "idle") setJustAllowed(false);
+  }, [state]);
+
+  // Timed against the hint rather than the state, so that pressing record while it
+  // pulses does not cancel the timer and strand the pulse on forever.
+  useEffect(() => {
+    if (!justAllowed) return;
     const settle = setTimeout(() => setJustAllowed(false), JUST_ALLOWED_MS);
     return () => clearTimeout(settle);
-  }, [state]);
+  }, [justAllowed]);
 
   const label = (() => {
     if (needsSetup) return t("voiceSearch.setUp");
@@ -55,23 +65,23 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
   })();
 
   return (
-    <Button
+    <button
       type="button"
-      variant="outline"
-      size="icon"
-      className={cn(
-        "relative h-10 w-10 rounded-full",
-        listening && "border-destructive text-destructive",
-        // Dashed for both, because both mean the press opens a step of its own rather
-        // than the microphone.
-        (needsSetup || needsPermission) && "border-dashed text-muted-foreground"
-      )}
       // Pressed again to finish speaking, which is how a reader says they are done
       // rather than waiting out the cap.
       onClick={listening ? onStop : onStart}
       disabled={disabled || working}
       aria-label={label}
       title={label}
+      className={cn(
+        // The same segment as submit, divider and all, so the field stays one row.
+        "form-field-shell__trailing relative flex w-10 shrink-0 items-center justify-center border-l bg-background hover:bg-accent disabled:pointer-events-none disabled:opacity-50",
+        listening
+          ? "text-destructive"
+          : needsSetup || needsPermission
+            ? "text-muted-foreground"
+            : "text-foreground"
+      )}
       {...cyAttr("voice-search-button")}
     >
       {working ? (
@@ -87,16 +97,22 @@ const VoiceSearchButton = ({ state, onStart, onStop, disabled }: VoiceSearchButt
         <span
           aria-hidden
           className={cn(
-            // Decorative, and the state is already carried by the icon and the border,
-            // so a reader who asked for less movement loses nothing by it stopping.
-            "absolute inset-0 animate-ping rounded-full border motion-reduce:animate-none",
+            // Inset rather than centred by a translate, because ping animates the
+            // transform: a translate here would be dropped the moment it began and
+            // the ring would expand from the corner.
+            //
+            // Inset by a quarter of the segment leaves a ring half its width, so that
+            // ping doubling it lands exactly on the segment's own bounds. The field
+            // clips whatever leaves it, so a wider ring would expand into a straight
+            // edge.
+            "absolute inset-2.5 animate-ping rounded-full border motion-reduce:animate-none",
             // Red says recording. Being ready is not an alarm, so it borrows the
             // ordinary accent instead.
             listening ? "border-destructive" : "border-primary"
           )}
         />
       )}
-    </Button>
+    </button>
   );
 };
 

--- a/frontend/src/services/speech/__tests__/microphone-permission.test.ts
+++ b/frontend/src/services/speech/__tests__/microphone-permission.test.ts
@@ -101,11 +101,11 @@ describe('requestMicrophone', () => {
   });
 
   /**
-   * Releasing it here would take the device down again, and listening that starts
-   * straight afterwards would open against a microphone still being torn down and
-   * hear nothing. That is the whole reason the caller is given it to hold.
+   * Handed back rather than closed here, so that the caller decides when to let go:
+   * Android allows one holder at a time, and releasing has to happen before listening
+   * reaches for the device rather than whenever this call happens to finish.
    */
-  it('hands the stream back still open, for listening to take over', async () => {
+  it('hands the stream back still open, for the caller to let go of', async () => {
     const stop = vi.fn();
     const stream = { getTracks: () => [{ stop }] };
     vi.stubGlobal('navigator', {
@@ -162,7 +162,7 @@ describe('requestMicrophone', () => {
 });
 
 describe('releaseMicrophone', () => {
-  it('closes the device, once listening has its own hold on it', () => {
+  it('closes the device, so that whatever listens next can have it', () => {
     const stop = vi.fn();
 
     releaseMicrophone({ getTracks: () => [{ stop }] } as unknown as MediaStream);

--- a/frontend/src/services/speech/__tests__/microphone-permission.test.ts
+++ b/frontend/src/services/speech/__tests__/microphone-permission.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   forgetMicrophoneGrant,
   isMicrophoneGranted,
+  releaseMicrophone,
   requestMicrophone,
 } from '../microphone-permission';
 import { MicrophoneUnavailableError } from '../types';
@@ -86,17 +87,22 @@ describe('requestMicrophone', () => {
     localStorage.clear();
   });
 
-  it('lets the microphone go again, since only the grant was wanted', async () => {
+  /**
+   * Releasing it here would take the device down again, and listening that starts
+   * straight afterwards would open against a microphone still being torn down and
+   * hear nothing. That is the whole reason the caller is given it to hold.
+   */
+  it('hands the stream back still open, for listening to take over', async () => {
     const stop = vi.fn();
+    const stream = { getTracks: () => [{ stop }] };
     vi.stubGlobal('navigator', {
-      mediaDevices: {
-        getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [{ stop }] }),
-      },
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
     });
 
-    await requestMicrophone();
+    const granted = await requestMicrophone();
 
-    expect(stop).toHaveBeenCalledTimes(1);
+    expect(granted).toBe(stream);
+    expect(stop).not.toHaveBeenCalled();
   });
 
   it('reports a refusal as a microphone failure, which the reader can act on', async () => {
@@ -116,6 +122,16 @@ describe('requestMicrophone', () => {
 
     await expect(requestMicrophone()).rejects.toBeInstanceOf(MicrophoneUnavailableError);
     expect(await isMicrophoneGranted()).toBe(false);
+  });
+});
+
+describe('releaseMicrophone', () => {
+  it('closes the device, once listening has its own hold on it', () => {
+    const stop = vi.fn();
+
+    releaseMicrophone({ getTracks: () => [{ stop }] } as unknown as MediaStream);
+
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/services/speech/__tests__/microphone-permission.test.ts
+++ b/frontend/src/services/speech/__tests__/microphone-permission.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   forgetMicrophoneGrant,
-  isMicrophoneGranted,
+  getMicrophonePermission,
+  getMicrophoneResetPlatform,
   releaseMicrophone,
   requestMicrophone,
 } from '../microphone-permission';
@@ -26,57 +27,69 @@ function useWorkingLocalStorage(): void {
   });
 }
 
+/** A rejection of the shape getUserMedia gives, which is told apart by its name. */
+function failWith(name: string): Error {
+  const cause = new Error(name);
+  cause.name = name;
+  return cause;
+}
+
 /**
  * Settling permission before a recognition starts is the whole point of this, so what
  * counts as settled is worth pinning down: a first press that starts listening while
  * the prompt is still up hears nothing at all.
  */
-describe('isMicrophoneGranted', () => {
+describe('getMicrophonePermission', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     localStorage.clear();
   });
 
-  it('is granted where the browser says so', async () => {
+  it('is granted where the browser says so, so a press can listen at once', async () => {
     vi.stubGlobal('navigator', {
       permissions: { query: vi.fn().mockResolvedValue({ state: 'granted' }) },
     });
-    expect(await isMicrophoneGranted()).toBe(true);
+    expect(await getMicrophonePermission()).toBe('granted');
   });
 
-  it('is not granted where the reader has yet to be asked', async () => {
+  it('is still to be asked where the reader has not been', async () => {
     vi.stubGlobal('navigator', {
       permissions: { query: vi.fn().mockResolvedValue({ state: 'prompt' }) },
     });
-    expect(await isMicrophoneGranted()).toBe(false);
+    expect(await getMicrophonePermission()).toBe('prompt');
   });
 
-  it('is not granted where it was refused', async () => {
+  /**
+   * Told apart from not yet asked, because a press cannot undo it: asking again is
+   * refused without a prompt, so the reader has to be sent to browser settings.
+   */
+  it('is refused where it was refused, which no press can undo', async () => {
     vi.stubGlobal('navigator', {
       permissions: { query: vi.fn().mockResolvedValue({ state: 'denied' }) },
     });
-    expect(await isMicrophoneGranted()).toBe(false);
+    expect(await getMicrophonePermission()).toBe('denied');
   });
 
   /**
    * Safari will not answer for the microphone, and asking getUserMedia to find out
-   * would show the very prompt being asked about, so a past grant is remembered.
+   * would show the very prompt being asked about, so a past grant is remembered. A
+   * refusal cannot be known there ahead of a press at all.
    */
   it('falls back to a remembered grant where the browser will not say', async () => {
     useWorkingLocalStorage();
-    vi.stubGlobal('navigator', {
+    const unanswered = {
       permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
-    });
-    expect(await isMicrophoneGranted()).toBe(false);
+    };
+    vi.stubGlobal('navigator', unanswered);
+    expect(await getMicrophonePermission()).toBe('prompt');
 
-    const stream = { getTracks: () => [{ stop: vi.fn() }] };
     vi.stubGlobal('navigator', {
-      permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
-      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+      ...unanswered,
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) },
     });
     await requestMicrophone();
 
-    expect(await isMicrophoneGranted()).toBe(true);
+    expect(await getMicrophonePermission()).toBe('granted');
   });
 });
 
@@ -105,9 +118,32 @@ describe('requestMicrophone', () => {
     expect(stop).not.toHaveBeenCalled();
   });
 
-  it('reports a refusal as a microphone failure, which the reader can act on', async () => {
+  it('marks a refusal as refused, since only that can be undone in settings', async () => {
     vi.stubGlobal('navigator', {
-      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowedError')) },
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(failWith('NotAllowedError')) },
+    });
+
+    await expect(requestMicrophone()).rejects.toMatchObject({
+      name: 'MicrophoneUnavailableError',
+      denied: true,
+    });
+  });
+
+  /**
+   * A device with no microphone is not a refusal, and sending that reader to a
+   * setting would send them after something that is not there.
+   */
+  it('does not call a missing microphone a refusal', async () => {
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(failWith('NotFoundError')) },
+    });
+
+    await expect(requestMicrophone()).rejects.toMatchObject({ denied: false });
+  });
+
+  it('reports any failure as a microphone failure the reader is told about', async () => {
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(failWith('NotAllowedError')) },
     });
 
     await expect(requestMicrophone()).rejects.toBeInstanceOf(MicrophoneUnavailableError);
@@ -117,11 +153,11 @@ describe('requestMicrophone', () => {
     useWorkingLocalStorage();
     vi.stubGlobal('navigator', {
       permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
-      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowedError')) },
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(failWith('NotAllowedError')) },
     });
 
     await expect(requestMicrophone()).rejects.toBeInstanceOf(MicrophoneUnavailableError);
-    expect(await isMicrophoneGranted()).toBe(false);
+    expect(await getMicrophonePermission()).toBe('prompt');
   });
 });
 
@@ -132,6 +168,68 @@ describe('releaseMicrophone', () => {
     releaseMicrophone({ getTracks: () => [{ stop }] } as unknown as MediaStream);
 
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Which steps to give depends on where the setting lives, which is a matter of
+ * platform rather than of browser: every browser on iOS is the same WebKit underneath
+ * and shares one place to change it.
+ */
+describe('getMicrophoneResetPlatform', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const AGENTS: Array<[string, string, string]> = [
+    [
+      'ios',
+      'iPhone Safari',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    ],
+    [
+      'ios',
+      'Chrome on iOS, which is WebKit underneath',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1',
+    ],
+    [
+      'safari',
+      'Safari on macOS',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    ],
+    [
+      'android',
+      'Chrome on Android',
+      'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+    ],
+    [
+      'chrome',
+      'Chrome on a desktop',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    ],
+    [
+      'firefox',
+      'Firefox on a desktop',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0',
+    ],
+  ];
+
+  it.each(AGENTS)('describes %s for %s', (platform, _name, userAgent) => {
+    vi.stubGlobal('navigator', { userAgent, maxTouchPoints: 0 });
+    expect(getMicrophoneResetPlatform()).toBe(platform);
+  });
+
+  /** An iPad claims to be a Mac, and gives itself away by having a touchscreen. */
+  it('describes ios for an iPad claiming to be a Mac', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      maxTouchPoints: 5,
+    });
+    expect(getMicrophoneResetPlatform()).toBe('ios');
+  });
+
+  it('falls back to something true of every browser', () => {
+    vi.stubGlobal('navigator', { userAgent: 'some browser nobody has heard of', maxTouchPoints: 0 });
+    expect(getMicrophoneResetPlatform()).toBe('generic');
   });
 });
 
@@ -147,16 +245,15 @@ describe('forgetMicrophoneGrant', () => {
 
   it('drops a remembered grant so it is asked for again', async () => {
     useWorkingLocalStorage();
-    const stream = { getTracks: () => [{ stop: vi.fn() }] };
     vi.stubGlobal('navigator', {
       permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
-      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) },
     });
     await requestMicrophone();
-    expect(await isMicrophoneGranted()).toBe(true);
+    expect(await getMicrophonePermission()).toBe('granted');
 
     forgetMicrophoneGrant();
 
-    expect(await isMicrophoneGranted()).toBe(false);
+    expect(await getMicrophonePermission()).toBe('prompt');
   });
 });

--- a/frontend/src/services/speech/__tests__/microphone-permission.test.ts
+++ b/frontend/src/services/speech/__tests__/microphone-permission.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  forgetMicrophoneGrant,
+  isMicrophoneGranted,
+  requestMicrophone,
+} from '../microphone-permission';
+import { MicrophoneUnavailableError } from '../types';
+
+/**
+ * The shared test setup replaces localStorage with a stub that always reads back
+ * null, so a remembered grant could never be observed through it. Tests that turn on
+ * remembering install a working store of their own instead.
+ */
+function useWorkingLocalStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+}
+
+/**
+ * Settling permission before a recognition starts is the whole point of this, so what
+ * counts as settled is worth pinning down: a first press that starts listening while
+ * the prompt is still up hears nothing at all.
+ */
+describe('isMicrophoneGranted', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('is granted where the browser says so', async () => {
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockResolvedValue({ state: 'granted' }) },
+    });
+    expect(await isMicrophoneGranted()).toBe(true);
+  });
+
+  it('is not granted where the reader has yet to be asked', async () => {
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockResolvedValue({ state: 'prompt' }) },
+    });
+    expect(await isMicrophoneGranted()).toBe(false);
+  });
+
+  it('is not granted where it was refused', async () => {
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockResolvedValue({ state: 'denied' }) },
+    });
+    expect(await isMicrophoneGranted()).toBe(false);
+  });
+
+  /**
+   * Safari will not answer for the microphone, and asking getUserMedia to find out
+   * would show the very prompt being asked about, so a past grant is remembered.
+   */
+  it('falls back to a remembered grant where the browser will not say', async () => {
+    useWorkingLocalStorage();
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
+    });
+    expect(await isMicrophoneGranted()).toBe(false);
+
+    const stream = { getTracks: () => [{ stop: vi.fn() }] };
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    await requestMicrophone();
+
+    expect(await isMicrophoneGranted()).toBe(true);
+  });
+});
+
+describe('requestMicrophone', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('lets the microphone go again, since only the grant was wanted', async () => {
+    const stop = vi.fn();
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [{ stop }] }),
+      },
+    });
+
+    await requestMicrophone();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a refusal as a microphone failure, which the reader can act on', async () => {
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowedError')) },
+    });
+
+    await expect(requestMicrophone()).rejects.toBeInstanceOf(MicrophoneUnavailableError);
+  });
+
+  it('does not remember a grant that was refused', async () => {
+    useWorkingLocalStorage();
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
+      mediaDevices: { getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowedError')) },
+    });
+
+    await expect(requestMicrophone()).rejects.toBeInstanceOf(MicrophoneUnavailableError);
+    expect(await isMicrophoneGranted()).toBe(false);
+  });
+});
+
+/**
+ * A grant withdrawn in browser settings after the fact would otherwise leave a
+ * remembered one that is no longer true, and every press would be refused.
+ */
+describe('forgetMicrophoneGrant', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('drops a remembered grant so it is asked for again', async () => {
+    useWorkingLocalStorage();
+    const stream = { getTracks: () => [{ stop: vi.fn() }] };
+    vi.stubGlobal('navigator', {
+      permissions: { query: vi.fn().mockRejectedValue(new TypeError('unsupported')) },
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    await requestMicrophone();
+    expect(await isMicrophoneGranted()).toBe(true);
+
+    forgetMicrophoneGrant();
+
+    expect(await isMicrophoneGranted()).toBe(false);
+  });
+});

--- a/frontend/src/services/speech/__tests__/native-recognizer.test.ts
+++ b/frontend/src/services/speech/__tests__/native-recognizer.test.ts
@@ -96,3 +96,97 @@ describe('on-device recognition', () => {
     expect(seen).not.toHaveProperty('processLocally');
   });
 });
+
+/**
+ * Safari holds the microphone after a recognition has ended, so the reader was left
+ * shown as being listened to long after their search had come back, with nothing on
+ * the page that would stop it. Chrome lets go by itself, which is why this only
+ * showed there.
+ */
+describe('letting go of the microphone', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** A recognition that records what was asked of it and can be driven by hand. */
+  function stubRecognition() {
+    const calls: string[] = [];
+    class Recognition {
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult: ((event: unknown) => void) | null = null;
+      onerror: ((event: { error?: string }) => void) | null = null;
+      onend: (() => void) | null = null;
+      static latest: Recognition | null = null;
+      constructor() {
+        Recognition.latest = this;
+      }
+      start() {
+        calls.push('start');
+      }
+      stop() {
+        calls.push('stop');
+      }
+      abort() {
+        calls.push('abort');
+      }
+    }
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('SpeechRecognition', Recognition);
+    return { calls, get current() { return Recognition.latest!; } };
+  }
+
+  it('lets go once the recognition reports itself ended', async () => {
+    const stub = stubRecognition();
+    const { createNativeRecognizer } = await import('../native-recognizer');
+
+    const session = createNativeRecognizer().listen('en');
+    stub.current.onend?.();
+    await session.transcript;
+
+    expect(stub.calls).toContain('abort');
+  });
+
+  /** Aborting twice, or after it has already ended, must not reach for it again. */
+  it('lets go only once, however often it is asked', async () => {
+    const stub = stubRecognition();
+    const { createNativeRecognizer } = await import('../native-recognizer');
+
+    const session = createNativeRecognizer().listen('en');
+    stub.current.onend?.();
+    await session.transcript;
+    session.abort();
+    session.abort();
+
+    expect(stub.calls.filter((call) => call === 'abort')).toHaveLength(1);
+  });
+
+  /**
+   * Abandoning a session has to settle it too, or whoever is waiting on the transcript
+   * waits for good. A reader who changed their mind said nothing, so it settles empty.
+   */
+  it('settles empty when abandoned, rather than leaving the caller waiting', async () => {
+    const stub = stubRecognition();
+    const { createNativeRecognizer } = await import('../native-recognizer');
+
+    const session = createNativeRecognizer().listen('en');
+    session.abort();
+
+    await expect(session.transcript).resolves.toBe('');
+  });
+
+  /**
+   * Asking it to stop is asking for what it heard, so the microphone stays until the
+   * recognition itself reports ended: letting go here would cut off the answer.
+   */
+  it('does not let go merely because it was asked to stop', async () => {
+    const stub = stubRecognition();
+    const { createNativeRecognizer } = await import('../native-recognizer');
+
+    const session = createNativeRecognizer().listen('en');
+    session.stop();
+
+    expect(stub.calls).toContain('stop');
+    expect(stub.calls).not.toContain('abort');
+  });
+});

--- a/frontend/src/services/speech/microphone-permission.ts
+++ b/frontend/src/services/speech/microphone-permission.ts
@@ -1,0 +1,86 @@
+import { MicrophoneUnavailableError } from './types';
+
+/**
+ * Settles microphone permission before a recognition is started.
+ *
+ * The browser's own recogniser opens the microphone itself, so nothing here is
+ * needed to record. It exists because of *when* that happens: starting a
+ * recognition has to be the first thing a press does, with nothing awaited before
+ * it, or Safari refuses it for want of a user gesture. On a first ever press that
+ * leaves the recognition running against a microphone that is not open yet, while
+ * the reader is still answering the permission prompt, and it hears nothing at all.
+ *
+ * Asking separately, in a press of its own, is what lets permission be waited for.
+ */
+
+/**
+ * Remembered because Safari will not answer permissions.query() for the
+ * microphone, and asking getUserMedia() to find out would show the very prompt
+ * being asked about. A grant survives reloads, so a remembered one is worth more
+ * than a prompt the reader did not ask for.
+ */
+const GRANTED_KEY = 'chordium_microphone_granted';
+
+function remember(granted: boolean): void {
+  try {
+    if (granted) localStorage.setItem(GRANTED_KEY, '1');
+    else localStorage.removeItem(GRANTED_KEY);
+  } catch {
+    // Private modes refuse storage. Costs a prompt next time, nothing worse.
+  }
+}
+
+function remembered(): boolean {
+  try {
+    return localStorage.getItem(GRANTED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the microphone is already granted, so a press can start listening at
+ * once rather than asking first.
+ *
+ * "Denied" and "not yet asked" are both false: neither can hear anything without
+ * the reader being asked, which is the same next step either way.
+ */
+export async function isMicrophoneGranted(): Promise<boolean> {
+  try {
+    const status = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+    const granted = status.state === 'granted';
+    remember(granted);
+    return granted;
+  } catch {
+    return remembered();
+  }
+}
+
+/**
+ * Asks for the microphone and lets it go again immediately.
+ *
+ * The stream itself is not wanted: the recogniser opens its own. All this leaves
+ * behind is the grant, so that the press after this one can start listening with
+ * the microphone already open.
+ */
+export async function requestMicrophone(): Promise<void> {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    stream.getTracks().forEach((track) => track.stop());
+    remember(true);
+  } catch (cause) {
+    remember(false);
+    throw new MicrophoneUnavailableError(String(cause));
+  }
+}
+
+/**
+ * Called when a recognition is refused for want of permission, so that a grant
+ * withdrawn in browser settings after the fact is asked for again rather than
+ * assumed from what was remembered.
+ */
+export function forgetMicrophoneGrant(): void {
+  remember(false);
+}

--- a/frontend/src/services/speech/microphone-permission.ts
+++ b/frontend/src/services/speech/microphone-permission.ts
@@ -59,21 +59,30 @@ export async function isMicrophoneGranted(): Promise<boolean> {
 }
 
 /**
- * Asks for the microphone and lets it go again immediately.
+ * Asks for the microphone and hands back the open stream.
  *
- * The stream itself is not wanted: the recogniser opens its own. All this leaves
- * behind is the grant, so that the press after this one can start listening with
- * the microphone already open.
+ * The stream is not what was wanted, since the recogniser opens its own, but it is
+ * worth holding rather than dropping: releasing it the moment the grant arrives
+ * takes the device down again, and listening that starts straight afterwards can
+ * open against a microphone still being torn down and hear nothing. Held until
+ * listening has its own hold, the device never goes down in between.
+ *
+ * The caller owns it, and must release it with `releaseMicrophone`.
  */
-export async function requestMicrophone(): Promise<void> {
+export async function requestMicrophone(): Promise<MediaStream> {
   try {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    stream.getTracks().forEach((track) => track.stop());
     remember(true);
+    return stream;
   } catch (cause) {
     remember(false);
     throw new MicrophoneUnavailableError(String(cause));
   }
+}
+
+/** Lets go of a stream from `requestMicrophone`, closing the device with it. */
+export function releaseMicrophone(stream: MediaStream): void {
+  stream.getTracks().forEach((track) => track.stop());
 }
 
 /**

--- a/frontend/src/services/speech/microphone-permission.ts
+++ b/frontend/src/services/speech/microphone-permission.ts
@@ -38,23 +38,31 @@ function remembered(): boolean {
   }
 }
 
+/** What the browser will say about the microphone before anything is asked of it. */
+export type MicrophonePermission = 'granted' | 'denied' | 'prompt';
+
 /**
- * Whether the microphone is already granted, so a press can start listening at
- * once rather than asking first.
+ * Where the microphone stands, so that a press can start listening at once, ask, or
+ * explain itself, rather than all three looking the same.
  *
- * "Denied" and "not yet asked" are both false: neither can hear anything without
- * the reader being asked, which is the same next step either way.
+ * Refused is worth telling apart from not yet asked: a press cannot undo a refusal,
+ * and asking again would silently do nothing, so the reader has to be told where to
+ * undo it instead.
+ *
+ * Safari will not answer, and asking getUserMedia to find out would show the very
+ * prompt being asked about. A remembered grant stands in there, and a refusal cannot
+ * be known ahead of a press at all: it surfaces when one is refused.
  */
-export async function isMicrophoneGranted(): Promise<boolean> {
+export async function getMicrophonePermission(): Promise<MicrophonePermission> {
   try {
     const status = await navigator.permissions.query({
       name: 'microphone' as PermissionName,
     });
-    const granted = status.state === 'granted';
-    remember(granted);
-    return granted;
+    const state = status.state as MicrophonePermission;
+    remember(state === 'granted');
+    return state;
   } catch {
-    return remembered();
+    return remembered() ? 'granted' : 'prompt';
   }
 }
 
@@ -76,8 +84,41 @@ export async function requestMicrophone(): Promise<MediaStream> {
     return stream;
   } catch (cause) {
     remember(false);
-    throw new MicrophoneUnavailableError(String(cause));
+    throw new MicrophoneUnavailableError(String(cause), isRefusal(cause));
   }
+}
+
+/**
+ * Whether the browser refused rather than failed. A refusal is the reader's, and can
+ * only be undone in browser settings; anything else is the device's, and telling them
+ * to change a setting would send them after something that is not there.
+ */
+function isRefusal(cause: unknown): boolean {
+  if (!(cause instanceof Error)) return false;
+  return cause.name === 'NotAllowedError' || cause.name === 'SecurityError';
+}
+
+/** Which browser's route back to a refused microphone should be described. */
+export type MicrophoneResetPlatform = 'ios' | 'safari' | 'android' | 'chrome' | 'firefox' | 'generic';
+
+/**
+ * Which set of steps will get the reader back to a working microphone.
+ *
+ * By platform rather than by browser, because that is what decides where the setting
+ * lives: every browser on iOS is the same WebKit underneath and shares one place to
+ * change it, whoever wrapped it.
+ */
+export function getMicrophoneResetPlatform(): MicrophoneResetPlatform {
+  const nav = typeof navigator === 'undefined' ? undefined : navigator;
+  const ua = nav?.userAgent ?? '';
+  // An iPad says Macintosh, and gives itself away by having a touchscreen.
+  const isIos = /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && (nav?.maxTouchPoints ?? 0) > 1);
+  if (isIos) return 'ios';
+  if (/Firefox\/|FxiOS/.test(ua)) return 'firefox';
+  if (/Android/.test(ua)) return 'android';
+  if (/Chrome|Chromium|Edg|OPR/.test(ua)) return 'chrome';
+  if (/Safari\//.test(ua)) return 'safari';
+  return 'generic';
 }
 
 /** Lets go of a stream from `requestMicrophone`, closing the device with it. */

--- a/frontend/src/services/speech/microphone-permission.ts
+++ b/frontend/src/services/speech/microphone-permission.ts
@@ -69,11 +69,12 @@ export async function getMicrophonePermission(): Promise<MicrophonePermission> {
 /**
  * Asks for the microphone and hands back the open stream.
  *
- * The stream is not what was wanted, since the recogniser opens its own, but it is
- * worth holding rather than dropping: releasing it the moment the grant arrives
- * takes the device down again, and listening that starts straight afterwards can
- * open against a microphone still being torn down and hear nothing. Held until
- * listening has its own hold, the device never goes down in between.
+ * The stream is not what was wanted, since the recogniser opens its own. It is handed
+ * back rather than closed here so that the caller decides when to let go, which
+ * matters: Android hands the microphone to one holder at a time, so ours has to be
+ * released before listening reaches for it, or its recogniser starts against a device
+ * it cannot have and reports silence. Desktop shares it happily and does not care
+ * either way.
  *
  * The caller owns it, and must release it with `releaseMicrophone`.
  */
@@ -121,7 +122,10 @@ export function getMicrophoneResetPlatform(): MicrophoneResetPlatform {
   return 'generic';
 }
 
-/** Lets go of a stream from `requestMicrophone`, closing the device with it. */
+/**
+ * Lets go of a stream from `requestMicrophone`, closing the device with it, so that
+ * whatever listens next can have it.
+ */
 export function releaseMicrophone(stream: MediaStream): void {
   stream.getTracks().forEach((track) => track.stop());
 }

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -95,11 +95,22 @@ export function createNativeRecognizer(): Recognizer {
       /**
        * Lets go of the microphone, once and for all.
        *
-       * Safari holds it after a recognition has ended, so the reader was still shown
-       * as being listened to long after their search had come back, with nothing on the
-       * page that would stop it. Chrome lets go by itself. Aborting makes both let go,
-       * and the handlers come off first so that aborting cannot arrive back through
-       * them.
+       * Chrome releases the device by itself once a recognition ends. Aborting makes
+       * that deterministic rather than left to it, and settles a session that was
+       * abandoned instead of leaving whoever awaited the transcript waiting for good.
+       * The handlers come off first, so that aborting cannot arrive back through them.
+       *
+       * It does not help Safari, and nothing here can. WebKit gives speech recognition
+       * its own capture manager, separate from the one behind getUserMedia, and it
+       * fails to unset the audio session once capture finishes: macOS and iOS go on
+       * showing the microphone as in use until the tab is reloaded or closed. That is
+       * https://bugs.webkit.org/show_bug.cgi?id=219671, filed in 2020 and still open on
+       * current Safari as of August 2026.
+       *
+       * stop(), abort(), detaching the handlers, and releasing our own stream were each
+       * confirmed on a real Safari to run without error and change nothing, so they are
+       * not worth trying again. A reader on WebKit is told in words instead, from
+       * useVoiceSearch.
        */
       let releasing = false;
       const release = () => {

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -91,7 +91,36 @@ export function createNativeRecognizer(): Recognizer {
       // recognition, which is the default, works on all of them.
 
       let heard = '';
+
+      /**
+       * Lets go of the microphone, once and for all.
+       *
+       * Safari holds it after a recognition has ended, so the reader was still shown
+       * as being listened to long after their search had come back, with nothing on the
+       * page that would stop it. Chrome lets go by itself. Aborting makes both let go,
+       * and the handlers come off first so that aborting cannot arrive back through
+       * them.
+       */
+      let releasing = false;
+      const release = () => {
+        if (releasing) return;
+        releasing = true;
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognition.onend = null;
+        try {
+          recognition.abort();
+        } catch {
+          // Already finished, so there is nothing left to let go of.
+        }
+      };
+
+      // Held so that abandoning a session settles it rather than leaving whoever is
+      // waiting on the transcript waiting for good.
+      let giveUp!: (transcript: string) => void;
+
       const transcript = new Promise<string>((resolve, reject) => {
+        giveUp = resolve;
         recognition.onresult = (event) => {
           for (let i = 0; i < event.results.length; i += 1) {
             const result = event.results[i];
@@ -102,6 +131,7 @@ export function createNativeRecognizer(): Recognizer {
         // their mind, so they settle empty rather than as failures.
         recognition.onerror = (event) => {
           const error = event.error ?? 'unknown';
+          release();
           if (error === 'no-speech' || error === 'aborted') resolve('');
           // Told apart from any other failure so that the reader is asked for the
           // microphone again rather than shown a fault they cannot act on.
@@ -111,15 +141,23 @@ export function createNativeRecognizer(): Recognizer {
         };
         // Settled on end rather than on the first result, so a recognition that
         // hears nothing finishes as an empty transcript instead of hanging.
-        recognition.onend = () => resolve(heard.trim());
+        recognition.onend = () => {
+          release();
+          resolve(heard.trim());
+        };
       });
 
       // Started in the same turn as the click, with nothing awaited in between.
       recognition.start();
 
       return {
+        // Asking it to stop is asking for what it heard, so the microphone is let go
+        // when the recognition reports itself ended rather than here.
         stop: () => recognition.stop(),
-        abort: () => recognition.abort(),
+        abort: () => {
+          release();
+          giveUp('');
+        },
         transcript,
       } satisfies RecognitionSession;
     },

--- a/frontend/src/services/speech/native-recognizer.ts
+++ b/frontend/src/services/speech/native-recognizer.ts
@@ -1,4 +1,9 @@
-import { RecognizerUnavailableError, type RecognitionSession, type Recognizer } from './types';
+import {
+  MicrophoneUnavailableError,
+  RecognizerUnavailableError,
+  type RecognitionSession,
+  type Recognizer,
+} from './types';
 
 /**
  * The browser's own SpeechRecognition, preferred wherever it exposes the API
@@ -98,6 +103,10 @@ export function createNativeRecognizer(): Recognizer {
         recognition.onerror = (event) => {
           const error = event.error ?? 'unknown';
           if (error === 'no-speech' || error === 'aborted') resolve('');
+          // Told apart from any other failure so that the reader is asked for the
+          // microphone again rather than shown a fault they cannot act on.
+          else if (error === 'not-allowed' || error === 'service-not-allowed')
+            reject(new MicrophoneUnavailableError(`The microphone was refused: ${error}`));
           else reject(new RecognizerUnavailableError(`Speech recognition failed: ${error}`));
         };
         // Settled on end rather than on the first result, so a recognition that

--- a/frontend/src/services/speech/types.ts
+++ b/frontend/src/services/speech/types.ts
@@ -62,8 +62,16 @@ export class RecognizerUnavailableError extends Error {
  * fall back to and the reader has to be told.
  */
 export class MicrophoneUnavailableError extends Error {
-  constructor(message: string) {
+  /**
+   * Whether the reader refused it, as opposed to the device having none. A refusal
+   * is the one case they can undo, and only in browser settings, so it is the one
+   * case worth telling them how to undo.
+   */
+  readonly denied: boolean;
+
+  constructor(message: string, denied = false) {
     super(message);
     this.name = 'MicrophoneUnavailableError';
+    this.denied = denied;
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -135,6 +135,13 @@ export default defineConfig(({ mode }) => {
         workbox: {
           cleanupOutdatedCaches: true,
           clientsClaim: true,
+          // Activated without waiting to be asked, because asking is not always
+          // possible: a build that crashes on load never renders the prompt that
+          // would accept the next one, which leaves the reader stuck on the broken
+          // build with no way forward. skipWaiting is run by the incoming worker, so
+          // it takes over regardless of what the installed one would have done, and
+          // is what makes a bad release recoverable at all.
+          skipWaiting: true,
 
           globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff2,json}'],
           // Re-enable navigateFallback but with better caching

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "headers": [
     {
+      "source": "/sw.js",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+    },
+    {
       "source": "/",
       "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
     },


### PR DESCRIPTION
- Voice search works on the first press: allowing the microphone starts listening straight away, rather than asking again and then hearing nothing. Fixed across Chrome, Safari, Samsung Internet and Comet, on desktop, Android and iOS

- The microphone is let go of before listening begins, which Android needs since it allows one holder at a time, and let go of again once a recognition ends, so it is not left open

- A refused microphone says so on the button and gives the steps to undo it for that platform, since no page can reset a permission itself

- Failures are now reported to the reader instead of leaving the button to slide back with no explanation, and repeated presses replace the message rather than stacking

- A new service worker activates without waiting to be asked, so a build that crashes on load can no longer leave a reader stuck on it with no way to update

- The microphone moved inside the search field beside submit, so the field is a single row

- Clearing recent searches now says that cached results go with it, asks in a bottom sheet on phones and a dialog on larger screens, and is translated

- Bumps `0.4.1` to `0.5.0`

On Safari the operating system goes on showing the microphone as in use after a search returns. That is WebKit's, not ours: speech recognition there never unsets its audio session ([bug 219671](https://bugs.webkit.org/show_bug.cgi?id=219671), open since 2020). `stop()`, `abort()`, detaching the handlers and releasing our own stream were each confirmed to run cleanly and change nothing, so a note tells the reader once a session that nothing is being recorded.
