### PR TITLE
chore: sync package-lock version with workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chordium-monorepo",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chordium-monorepo",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "workspaces": [
         "frontend",
         "backend",
@@ -27,7 +27,7 @@
     },
     "backend": {
       "name": "chordium-backend",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@chordium/scraping": "*",
@@ -68,7 +68,7 @@
     },
     "frontend": {
       "name": "chordium-frontend",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@chordium/scraping": "*",
         "@chordium/types": "^1.0.0",


### PR DESCRIPTION
- `package-lock.json` recorded the workspace versions as `0.4.0` while the three `package.json` files were already on `0.5.1`, since the `0.5.0` and `0.5.1` bumps never touched the lockfile
- Regenerated with `npm install --package-lock-only`, which updates only the four workspace version fields: root, `packages[""]`, `backend` and `frontend`
- No dependency changes — 6 of the 10 `"0.4.0"` strings in that file are unrelated packages, so this was resolved by npm rather than hand-edited
- `packages/types` is untouched, as `@chordium/types` is versioned independently at `1.0.0`
