### PR TITLE
fix: preserve chord formatting on save, fix scraper truncation and tab-toggle leaks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chordium-backend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/backend/server.js",
   "license": "MIT",
   "type": "module",

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -460,6 +460,18 @@ export function extractSongMetadata(): SongMetadata {
     if (notes.length === 6) {
       guitarTuning = notes as unknown as GuitarTuning;
     }
+  } else {
+    // Some pages render non-standard tuning as a plain "Afinação: <notes>"
+    // line at the very start of the pre block instead of a cifra_afi anchor.
+    const preElement = document.querySelector("pre");
+    const preText = preElement?.textContent || "";
+    const leadingTuningMatch = preText.match(/^Afinação:\s*([A-G][#b]?(?:\s+[A-G][#b]?){5})\s*\n+/i);
+    if (leadingTuningMatch) {
+      const notes = leadingTuningMatch[1].trim().split(/\s+/).filter(Boolean);
+      if (notes.length === 6) {
+        guitarTuning = notes as unknown as GuitarTuning;
+      }
+    }
   }
 
   return {
@@ -495,6 +507,11 @@ export function extractChordSheet(): ChordSheet {
     }
   });
 
+  // Some pages render non-standard tuning as a plain "Afinação: <notes>" line
+  // at the very start of the pre block instead of a cifra_afi anchor. Strip
+  // it so it doesn't leak into the chord sheet body as a lyric line.
+  const leadingTuningLineRegex = /^Afinação:\s*(?:[A-G][#b]?\s*){6}\s*\n+/i;
+  songChords = songChords.replace(leadingTuningLineRegex, "");
 
   function sanitizeNode(node: Node): string {
     if (node.nodeType === Node.TEXT_NODE) return node.textContent || "";
@@ -510,7 +527,10 @@ export function extractChordSheet(): ChordSheet {
     return `${openTag}${inner}</${tag}>`;
   }
 
-  const rawHtmlRaw = Array.from(preElement.childNodes).map(sanitizeNode).join("");
+  let rawHtmlRaw = Array.from(preElement.childNodes).map(sanitizeNode).join("");
+  // Same leading line as above, verbatim (it's a plain text node, not
+  // wrapped in <b>/<span>, so it appears unchanged in the sanitized HTML).
+  rawHtmlRaw = rawHtmlRaw.replace(leadingTuningLineRegex, "");
   // Wrap [Section Title] patterns in a span for styling
   // Wrap section titles and dedent continuation lines
   const rawHtml = (() => {

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -496,20 +496,48 @@ export function extractChordSheet(): ChordSheet {
   // Drops a bare section-title line when it's immediately followed (skipping
   // blank lines) by another one — the source sometimes repeats a section's
   // title right before its "Tab - <title>" counterpart with nothing of
-  // substance in between, which reads as a useless duplicate header.
+  // substance in between, which reads as a useless duplicate header. Only
+  // touches lines when a genuine duplicate is found — otherwise every line,
+  // including any surrounding blank ones, is left exactly as it was.
   function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
     const lines = text.split("\n");
     const result: string[] = [];
     for (const line of lines) {
       if (isHeaderLine(line.trim())) {
-        while (result.length > 0 && result[result.length - 1].trim() === "") {
-          result.pop();
-        }
-        if (result.length > 0 && isHeaderLine(result[result.length - 1].trim())) {
-          result.pop();
+        let j = result.length - 1;
+        while (j >= 0 && result[j].trim() === "") j--;
+        if (j >= 0 && isHeaderLine(result[j].trim())) {
+          result.length = j;
         }
       }
       result.push(line);
+    }
+    return result.join("\n");
+  }
+
+  // Ensures exactly one blank line before and after every header line (never
+  // zero, never more), except at the very start/end of the content where
+  // there's nothing to separate it from.
+  function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (isHeaderLine(line.trim())) {
+        while (result.length > 0 && result[result.length - 1].trim() === "") {
+          result.pop();
+        }
+        if (result.length > 0) result.push("");
+        result.push(line);
+        let k = i + 1;
+        while (k < lines.length && lines[k].trim() === "") k++;
+        if (k < lines.length) result.push("");
+        i = k;
+        continue;
+      }
+      result.push(line);
+      i++;
     }
     return result.join("\n");
   }
@@ -533,7 +561,9 @@ export function extractChordSheet(): ChordSheet {
   // it so it doesn't leak into the chord sheet body as a lyric line.
   const leadingTuningLineRegex = /^Afinação:\s*(?:[A-G][#b]?\s*){6}\s*\n+/i;
   songChords = songChords.replace(leadingTuningLineRegex, "");
-  songChords = dedupeAdjacentHeaders(songChords, (line) => /^\[[^\]]+\]$/.test(line));
+  const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
+  songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
+  songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
   function sanitizeNode(node: Node): string {
     if (node.nodeType === Node.TEXT_NODE) return node.textContent || "";
@@ -597,7 +627,8 @@ export function extractChordSheet(): ChordSheet {
       });
   })();
 
-  return { songChords, rawHtml: dedupeAdjacentHeaders(rawHtml, (line) => /^<span class="section-title">.*<\/span>$/.test(line)) };
+  const isSectionTitleLine = (line: string) => /^<span class="section-title">.*<\/span>$/.test(line);
+  return { songChords, rawHtml: normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtml, isSectionTitleLine), isSectionTitleLine) };
 }
 
 /**

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -494,23 +494,48 @@ export function extractChordSheet(): ChordSheet {
   if (!preElement) return { songChords: "" };
 
   // Drops a bare section-title line when it's immediately followed (skipping
-  // blank lines) by another one — the source sometimes repeats a section's
-  // title right before its "Tab - <title>" counterpart with nothing of
-  // substance in between, which reads as a useless duplicate header. Only
-  // touches lines when a genuine duplicate is found — otherwise every line,
-  // including any surrounding blank ones, is left exactly as it was.
-  function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
+  // blank lines) by another one, but ONLY when that's actually safe: if the
+  // second header is "Tab -"/"Dedilhado -" prefixed, its tab run is skipped
+  // ahead first, and the drop only happens if nothing but another header (or
+  // the end) follows. Some sections share one header for both a tab run and
+  // the real chords/lyrics that resume right after it (e.g. a bare "[X]"
+  // immediately followed by "[Tab - X]", with the section's actual lyrics
+  // appearing only after the tab content ends) — collapsing the pair there
+  // would leave that trailing content with no header of its own. Sections
+  // that really are just a duplicate ("[X]" then "[Tab - X]" with nothing
+  // else in the section) still collapse to the more specific one as before.
+  function dedupeAdjacentHeaders(
+    text: string,
+    isHeaderLine: (line: string) => boolean,
+    extractTitle: (line: string) => string | null,
+    isTabContinuation: (lines: string[], i: number) => boolean
+  ): string {
     const lines = text.split("\n");
     const result: string[] = [];
-    for (const line of lines) {
-      if (isHeaderLine(line.trim())) {
-        let j = result.length - 1;
-        while (j >= 0 && result[j].trim() === "") j--;
-        if (j >= 0 && isHeaderLine(result[j].trim())) {
-          result.length = j;
+    let i = 0;
+    while (i < lines.length) {
+      if (isHeaderLine(lines[i].trim())) {
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim() === "") j++;
+        if (j < lines.length && isHeaderLine(lines[j].trim())) {
+          const nextTitle = extractTitle(lines[j].trim());
+          const nextIsTabPrefixed = !!nextTitle && /^(tab|dedilhado)\b/i.test(nextTitle.trim());
+          if (nextIsTabPrefixed) {
+            let k = j + 1;
+            while (k < lines.length && isTabContinuation(lines, k)) k++;
+            const safeToCollapse = k >= lines.length || isHeaderLine(lines[k].trim());
+            if (safeToCollapse) {
+              i = j;
+              continue;
+            }
+          } else {
+            i = j;
+            continue;
+          }
         }
       }
-      result.push(line);
+      result.push(lines[i]);
+      i++;
     }
     return result.join("\n");
   }
@@ -567,7 +592,7 @@ export function extractChordSheet(): ChordSheet {
         result.push(line);
         continue;
       }
-      if (!insertedForSection && currentTitle && !/^tab\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
+      if (!insertedForSection && currentTitle && !/^(tab|dedilhado)\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
         result.push(makeHeaderLine("Tab - " + currentTitle));
         insertedForSection = true;
       }
@@ -595,6 +620,33 @@ export function extractChordSheet(): ChordSheet {
   // it so it doesn't leak into the chord sheet body as a lyric line.
   const leadingTuningLineRegex = /^Afinação:\s*(?:[A-G][#b]?\s*){6}\s*\n+/i;
   songChords = songChords.replace(leadingTuningLineRegex, "");
+  // Recognizes a chord-only line (e.g. "   Am               C   ") the same
+  // way isChordLine elsewhere in the app does: strip every chord token and
+  // check that nothing but whitespace/decoration is left.
+  const CHORD_TOKEN_SOURCE =
+    "[A-G][#b]?(?:m|maj|min|aug|dim|sus|add|maj7|m7|7M|9M|11M|13M|7|9|11|13|6|m6|m9|m11|m13|7sus4|7sus2|7b5|7b9|7#9|7#11|7#5|aug7|dim7|4|2)?(?:\\/[A-G][#b]?)?";
+  function isPlainChordOnlyLine(line: string): boolean {
+    if (!/[A-G]/.test(line)) return false;
+    const stripped = line.replace(new RegExp(CHORD_TOKEN_SOURCE, "g"), "");
+    return /^[\s()[\]{}xX0-9.,:-]*$/.test(stripped);
+  }
+  function isPlainTabContinuation(lines: string[], i: number): boolean {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed === "") return true;
+    if (/^[EBGDAe]\|[-\d]/.test(trimmed)) return true;
+    if (/^\s*Parte \d+ [Dd]e \d+\s*$/.test(line)) return true;
+    if (/^[ \t]*[↓↑][ \t↓↑]*$/.test(line)) return true;
+    if (isPlainChordOnlyLine(trimmed)) {
+      let j = i + 1;
+      while (j < lines.length && lines[j].trim() === "") j++;
+      if (j >= lines.length) return false;
+      const next = lines[j];
+      return /^[EBGDAe]\|[-\d]/.test(next.trim()) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(next);
+    }
+    return false;
+  }
+
   const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
   const isTabRunStartPlain = (line: string) => /^[EBGDAe]\|[-\d]/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
   songChords = insertMissingTabHeaders(
@@ -604,7 +656,12 @@ export function extractChordSheet(): ChordSheet {
     (title) => "[" + title + "]",
     isTabRunStartPlain
   );
-  songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
+  songChords = dedupeAdjacentHeaders(
+    songChords,
+    isBareBracketHeader,
+    (line) => line.match(/^\[([^\]]+)\]/)?.[1] ?? null,
+    isPlainTabContinuation
+  );
   songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
   function sanitizeNode(node: Node): string {
@@ -678,16 +735,57 @@ export function extractChordSheet(): ChordSheet {
       });
   })();
 
-  const isSectionTitleLine = (line: string) => /^<span class="section-title">.*<\/span>$/.test(line);
+  // Native markup wraps each tab sub-block in its own <span class="tablatura">,
+  // sometimes with a "[Section]" bracket right on the same line as its
+  // opening tag (e.g. "<span class="tablatura">[Dedilhado - Intro]") — so a
+  // header line and a tab-continuation line can each start with that tag.
+  const isSectionTitleLine = (line: string) =>
+    /^(?:<span class="tablatura">)?<span class="section-title">.*<\/span>$/.test(line);
+  function isHtmlTabContinuation(lines: string[], i: number): boolean {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed === "") return true;
+    if (
+      line.includes('<span class="tablatura">') ||
+      line.includes('<span class="cnt">') ||
+      line.includes("</span></span>")
+    ) {
+      return true;
+    }
+    if (/Parte \d+ [Dd]e \d+/.test(line)) return true;
+    if (/^[EBGDAe]\|[-\d]/.test(trimmed)) return true;
+    if (/^[ \t]*[↓↑][ \t↓↑]*$/.test(line)) return true;
+    if (/^(?:<b>[^<]*<\/b>\s*)+$/.test(trimmed)) {
+      let j = i + 1;
+      while (j < lines.length && lines[j].trim() === "") j++;
+      if (j >= lines.length) return false;
+      const next = lines[j];
+      return (
+        next.includes('<span class="tablatura">') ||
+        next.includes('<span class="cnt">') ||
+        /Parte \d+ [Dd]e \d+/.test(next) ||
+        /^[EBGDAe]\|[-\d]/.test(next.trim())
+      );
+    }
+    return false;
+  }
   const isTabRunStartHtml = (line: string) => /^<span class="tablatura">/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+  const extractTitleHtml = (line: string) =>
+    line.match(/^(?:<span class="tablatura">)?<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null;
   const rawHtmlWithTabHeaders = insertMissingTabHeaders(
     rawHtml,
-    (line) => /^<span class="section-title">/.test(line),
-    (line) => line.match(/^<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null,
+    (line) => /^(?:<span class="tablatura">)?<span class="section-title">/.test(line),
+    extractTitleHtml,
     (title) => '<span class="section-title">' + title + "</span>",
     isTabRunStartHtml
   );
-  return { songChords, rawHtml: normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine), isSectionTitleLine) };
+  return {
+    songChords,
+    rawHtml: normalizeHeaderBlankLines(
+      dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine, extractTitleHtml, isHtmlTabContinuation),
+      isSectionTitleLine
+    ),
+  };
 }
 
 /**

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -515,9 +515,10 @@ export function extractChordSheet(): ChordSheet {
     return result.join("\n");
   }
 
-  // Ensures exactly one blank line before and after every header line (never
-  // zero, never more), except at the very start/end of the content where
-  // there's nothing to separate it from.
+  // Ensures exactly one blank line before every header line (never zero,
+  // never more), except at the very start of the content where there's
+  // nothing to separate it from. No blank line is added after — the
+  // divider rendered under the header already provides that separation.
   function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
     const lines = text.split("\n");
     const result: string[] = [];
@@ -532,7 +533,6 @@ export function extractChordSheet(): ChordSheet {
         result.push(line);
         let k = i + 1;
         while (k < lines.length && lines[k].trim() === "") k++;
-        if (k < lines.length) result.push("");
         i = k;
         continue;
       }

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -542,6 +542,40 @@ export function extractChordSheet(): ChordSheet {
     return result.join("\n");
   }
 
+  // Some sections mix chord-only content and a tab block under a single
+  // header with no separate "Tab - <title>" counterpart (the source doesn't
+  // always split them the way it does for e.g. "[Intro]" + "[Tab - Intro]").
+  // Without that second header, the "hide tabs" toggle has nothing tab-named
+  // to strip and leaves the tab block's "Parte N de M" labels and dash lines
+  // behind. Detect where a tab run starts inside a section whose header
+  // isn't already "Tab"-prefixed, and insert one right before it.
+  function insertMissingTabHeaders(
+    text: string,
+    isHeaderLine: (line: string) => boolean,
+    extractTitle: (line: string) => string | null,
+    makeHeaderLine: (title: string) => string,
+    isTabRunStart: (line: string) => boolean
+  ): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    let currentTitle: string | null = null;
+    let insertedForSection = false;
+    for (const line of lines) {
+      if (isHeaderLine(line.trim())) {
+        currentTitle = extractTitle(line.trim());
+        insertedForSection = false;
+        result.push(line);
+        continue;
+      }
+      if (!insertedForSection && currentTitle && !/^tab\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
+        result.push(makeHeaderLine("Tab - " + currentTitle));
+        insertedForSection = true;
+      }
+      result.push(line);
+    }
+    return result.join("\n");
+  }
+
   let songChords = "";
   // Tab blocks are plain text too (their dash-drawn strings, e.g.
   // "E|----7-10-...|", are already self-identifying), so no wrapper markers
@@ -562,6 +596,14 @@ export function extractChordSheet(): ChordSheet {
   const leadingTuningLineRegex = /^Afinação:\s*(?:[A-G][#b]?\s*){6}\s*\n+/i;
   songChords = songChords.replace(leadingTuningLineRegex, "");
   const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
+  const isTabRunStartPlain = (line: string) => /^[EBGDAe]\|[-\d]/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+  songChords = insertMissingTabHeaders(
+    songChords,
+    (line) => /^\[[^\]]+\]/.test(line),
+    (line) => line.match(/^\[([^\]]+)\]/)?.[1] ?? null,
+    (title) => "[" + title + "]",
+    isTabRunStartPlain
+  );
   songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
   songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
@@ -583,6 +625,15 @@ export function extractChordSheet(): ChordSheet {
   // Same leading line as above, verbatim (it's a plain text node, not
   // wrapped in <b>/<span>, so it appears unchanged in the sanitized HTML).
   rawHtmlRaw = rawHtmlRaw.replace(leadingTuningLineRegex, "");
+  // Some tab blocks close the tablatura span before the last string, leaving
+  // the 6th string (e.g. "E|----|") as a bare line after </span></span> — or
+  // before a fret-hand direction row (e.g. "↓  ↑ ↓") that annotates the tab
+  // just above it. Absorb both back inside the cnt span so the whole tab
+  // block renders (and gets removed together when tabs are hidden) as one.
+  rawHtmlRaw = rawHtmlRaw.replace(
+    /(<\/span>)(<\/span>)((?:\n(?:[ \t]*[EADGBe]\|[-\d][^\n]*|[ \t]*[↓↑][ \t↓↑]*))+)/g,
+    (_m, closeCnt, closeTab, orphanLines) => orphanLines + closeCnt + closeTab
+  );
   // Wrap [Section Title] patterns in a span for styling
   // Wrap section titles and dedent continuation lines
   const rawHtml = (() => {
@@ -628,7 +679,15 @@ export function extractChordSheet(): ChordSheet {
   })();
 
   const isSectionTitleLine = (line: string) => /^<span class="section-title">.*<\/span>$/.test(line);
-  return { songChords, rawHtml: normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtml, isSectionTitleLine), isSectionTitleLine) };
+  const isTabRunStartHtml = (line: string) => /^<span class="tablatura">/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+  const rawHtmlWithTabHeaders = insertMissingTabHeaders(
+    rawHtml,
+    (line) => /^<span class="section-title">/.test(line),
+    (line) => line.match(/^<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null,
+    (title) => '<span class="section-title">' + title + "</span>",
+    isTabRunStartHtml
+  );
+  return { songChords, rawHtml: normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine), isSectionTitleLine) };
 }
 
 /**

--- a/backend/utils/dom-extractors.ts
+++ b/backend/utils/dom-extractors.ts
@@ -493,17 +493,38 @@ export function extractChordSheet(): ChordSheet {
   const preElement = document.querySelector("pre");
   if (!preElement) return { songChords: "" };
 
+  // Drops a bare section-title line when it's immediately followed (skipping
+  // blank lines) by another one — the source sometimes repeats a section's
+  // title right before its "Tab - <title>" counterpart with nothing of
+  // substance in between, which reads as a useless duplicate header.
+  function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    for (const line of lines) {
+      if (isHeaderLine(line.trim())) {
+        while (result.length > 0 && result[result.length - 1].trim() === "") {
+          result.pop();
+        }
+        if (result.length > 0 && isHeaderLine(result[result.length - 1].trim())) {
+          result.pop();
+        }
+      }
+      result.push(line);
+    }
+    return result.join("\n");
+  }
+
   let songChords = "";
+  // Tab blocks are plain text too (their dash-drawn strings, e.g.
+  // "E|----7-10-...|", are already self-identifying), so no wrapper markers
+  // are needed — bracket-style markers would collide with the "[Section]"
+  // convention used elsewhere and render as bogus section headers when
+  // rawHtml is unavailable.
   preElement.childNodes.forEach(function(node) {
     if (node.nodeType === Node.TEXT_NODE) {
       songChords += node.textContent || "";
     } else if (node.nodeType === Node.ELEMENT_NODE) {
-      const el = node as Element;
-      if (el.classList.contains("tablatura")) {
-        songChords += "[TAB]\n" + (el.textContent || "") + "\n[/TAB]\n";
-      } else {
-        songChords += el.textContent || "";
-      }
+      songChords += (node as Element).textContent || "";
     }
   });
 
@@ -512,6 +533,7 @@ export function extractChordSheet(): ChordSheet {
   // it so it doesn't leak into the chord sheet body as a lyric line.
   const leadingTuningLineRegex = /^Afinação:\s*(?:[A-G][#b]?\s*){6}\s*\n+/i;
   songChords = songChords.replace(leadingTuningLineRegex, "");
+  songChords = dedupeAdjacentHeaders(songChords, (line) => /^\[[^\]]+\]$/.test(line));
 
   function sanitizeNode(node: Node): string {
     if (node.nodeType === Node.TEXT_NODE) return node.textContent || "";
@@ -575,7 +597,7 @@ export function extractChordSheet(): ChordSheet {
       });
   })();
 
-  return { songChords, rawHtml };
+  return { songChords, rawHtml: dedupeAdjacentHeaders(rawHtml, (line) => /^<span class="section-title">.*<\/span>$/.test(line)) };
 }
 
 /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-frontend",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ChordDisplay/chord-display.css
+++ b/frontend/src/components/ChordDisplay/chord-display.css
@@ -39,14 +39,27 @@
   font-weight: 500;
 }
 
+/* Matches the search results section header style (SearchResultsSection.tsx):
+   same weight/tracking/size, and always the color it only shows on hover
+   there, since a chord sheet header has no separate "closed" state to dim
+   for. The gradient line below is the same divider search result headers
+   render under themselves. */
 #chord-sheet-viewer pre .section-title {
   display: block;
-  font-weight: 700;
+  font-weight: 600;
   font-size: 1rem;
-  border-left: 4px solid hsl(var(--primary));
-  padding-left: 0.5rem;
+  letter-spacing: -0.025em;
+  color: hsl(var(--foreground));
   white-space: normal;
   word-break: break-word;
+}
+
+#chord-sheet-viewer pre .section-title::after {
+  content: "";
+  display: block;
+  height: 1px;
+  margin-top: 0.5rem;
+  background: linear-gradient(to right, hsl(var(--border) / 0.6) 25%, transparent);
 }
 
 #chord-sheet-viewer pre .tablatura {

--- a/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
+++ b/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
@@ -48,6 +48,33 @@ function wrapChords(line: string): string {
   return line.replace(CHORD_REGEX, '<b>$1</b>');
 }
 
+// Ensures exactly one blank line before and after every header line (never
+// zero, never more), except at the very start/end of the content where
+// there's nothing to separate it from.
+function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (isHeaderLine(line.trim())) {
+      while (result.length > 0 && result[result.length - 1].trim() === '') {
+        result.pop();
+      }
+      if (result.length > 0) result.push('');
+      result.push(line);
+      let k = i + 1;
+      while (k < lines.length && lines[k].trim() === '') k++;
+      if (k < lines.length) result.push('');
+      i = k;
+      continue;
+    }
+    result.push(line);
+    i++;
+  }
+  return result.join('\n');
+}
+
 export function songChordsToRawHtml(songChords: string): string {
   const lines = songChords.split('\n');
   const result: string[] = [];
@@ -101,9 +128,8 @@ export function songChordsToRawHtml(songChords: string): string {
     i++;
   }
 
-  // Normalize spacing around section titles
-  return result.join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/\n{2,}(<span class="section-title">)/g, '\n\n$1')
-    .replace(/(<\/span>)\n\n+/g, '$1\n');
+  return normalizeHeaderBlankLines(
+    result.join('\n').replace(/\n{3,}/g, '\n\n'),
+    (line) => /^<span class="section-title">.*<\/span>$/.test(line)
+  );
 }

--- a/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
+++ b/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
@@ -48,9 +48,10 @@ function wrapChords(line: string): string {
   return line.replace(CHORD_REGEX, '<b>$1</b>');
 }
 
-// Ensures exactly one blank line before and after every header line (never
-// zero, never more), except at the very start/end of the content where
-// there's nothing to separate it from.
+// Ensures exactly one blank line before every header line (never zero,
+// never more), except at the very start of the content where there's
+// nothing to separate it from. No blank line is added after — the divider
+// rendered under the header already provides that separation.
 function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
   const lines = text.split('\n');
   const result: string[] = [];
@@ -65,7 +66,6 @@ function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) =>
       result.push(line);
       let k = i + 1;
       while (k < lines.length && lines[k].trim() === '') k++;
-      if (k < lines.length) result.push('');
       i = k;
       continue;
     }
@@ -101,14 +101,22 @@ export function songChordsToRawHtml(songChords: string): string {
       continue;
     }
 
-    // Tab block: collect consecutive tab lines (all 6 strings together)
+    // Tab block: collect consecutive tab lines (all 6 strings together).
+    // A block can hold several string-groups separated by a blank line each
+    // (e.g. "Parte 3 de 5" repeating the pattern) — kept as a single blank,
+    // not dropped, or the groups render mashed together and unreadable.
     if (isTabLine(line)) {
       const tabLines: string[] = [];
       while (i < lines.length && (isTabLine(lines[i]) || (tabLines.length > 0 && lines[i].trim() === ''))) {
         if (isTabLine(lines[i])) {
           tabLines.push(lines[i]);
+        } else if (tabLines[tabLines.length - 1]?.trim() !== '') {
+          tabLines.push('');
         }
         i++;
+      }
+      while (tabLines.length > 0 && tabLines[tabLines.length - 1].trim() === '') {
+        tabLines.pop();
       }
       if (tabLines.length > 0) {
         result.push('<span class="tablatura"><span class="cnt">' + tabLines.join('\n') + '</span></span>');

--- a/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
+++ b/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
@@ -115,7 +115,7 @@ export function songChordsToRawHtml(songChords: string): string {
     if (
       !insertedTabHeaderForSection &&
       currentTitle &&
-      !/^tab\b/i.test(currentTitle.trim()) &&
+      !/^(tab|dedilhado)\b/i.test(currentTitle.trim()) &&
       (isTabLine(line) || TAB_PART_LABEL_REGEX.test(line))
     ) {
       result.push('<span class="section-title">Tab - ' + translateSectionTitle(currentTitle) + '</span>');

--- a/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
+++ b/frontend/src/components/ChordDisplay/song-chords-to-raw-html.ts
@@ -75,10 +75,19 @@ function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) =>
   return result.join('\n');
 }
 
+const TAB_PART_LABEL_REGEX = /^\s*Parte \d+ [Dd]e \d+\s*$/;
+
 export function songChordsToRawHtml(songChords: string): string {
   const lines = songChords.split('\n');
   const result: string[] = [];
   let i = 0;
+  // Some sections mix chord-only content and a tab block under a single
+  // title with no separate "Tab - <title>" counterpart. Without that second
+  // header, the "hide tabs" toggle has nothing tab-named to strip and leaves
+  // the tab block behind. Track the section currently in scope so a
+  // "Tab - <title>" header can be inserted right before its tab run starts.
+  let currentTitle: string | null = null;
+  let insertedTabHeaderForSection = false;
 
   while (i < lines.length) {
     const line = lines[i];
@@ -90,6 +99,8 @@ export function songChordsToRawHtml(songChords: string): string {
     // chord-line check below.
     const sectionMatch = trimmed.match(/^\[([^\]]+)\]\s*(.*)$/);
     if (sectionMatch) {
+      currentTitle = sectionMatch[1];
+      insertedTabHeaderForSection = false;
       const translatedTitle = translateSectionTitle(sectionMatch[1]);
       result.push('<span class="section-title">' + translatedTitle + '</span>');
       const rest = sectionMatch[2];
@@ -101,14 +112,26 @@ export function songChordsToRawHtml(songChords: string): string {
       continue;
     }
 
-    // Tab block: collect consecutive tab lines (all 6 strings together).
-    // A block can hold several string-groups separated by a blank line each
-    // (e.g. "Parte 3 de 5" repeating the pattern) — kept as a single blank,
-    // not dropped, or the groups render mashed together and unreadable.
+    if (
+      !insertedTabHeaderForSection &&
+      currentTitle &&
+      !/^tab\b/i.test(currentTitle.trim()) &&
+      (isTabLine(line) || TAB_PART_LABEL_REGEX.test(line))
+    ) {
+      result.push('<span class="section-title">Tab - ' + translateSectionTitle(currentTitle) + '</span>');
+      insertedTabHeaderForSection = true;
+    }
+
+    // Tab block: collect consecutive tab lines (all 6 strings together), plus
+    // any fret-hand direction rows (e.g. "↓  ↑ ↓") annotating them. A block
+    // can hold several string-groups separated by a blank line each (e.g.
+    // "Parte 3 de 5" repeating the pattern) — kept as a single blank, not
+    // dropped, or the groups render mashed together and unreadable.
     if (isTabLine(line)) {
       const tabLines: string[] = [];
-      while (i < lines.length && (isTabLine(lines[i]) || (tabLines.length > 0 && lines[i].trim() === ''))) {
-        if (isTabLine(lines[i])) {
+      const continuesBlock = (l: string) => isTabLine(l) || /^[ \t]*[↓↑][ \t↓↑]*$/.test(l);
+      while (i < lines.length && (continuesBlock(lines[i]) || (tabLines.length > 0 && lines[i].trim() === ''))) {
+        if (continuesBlock(lines[i])) {
           tabLines.push(lines[i]);
         } else if (tabLines[tabLines.length - 1]?.trim() !== '') {
           tabLines.push('');

--- a/frontend/src/components/SongViewer.tsx
+++ b/frontend/src/components/SongViewer.tsx
@@ -141,7 +141,7 @@ const SongViewer = ({
 
   const hasTabs = useMemo(() => {
     if (chordSheetToDisplay.rawHtml?.includes("tablatura")) return true;
-    return (chordContentToDisplay || "").includes("[TAB]");
+    return /^[EBGDAe]\|[-\d]/m.test(chordContentToDisplay || "");
   }, [chordSheetToDisplay.rawHtml, chordContentToDisplay]);
 
   const {

--- a/frontend/src/hooks/useChordSheetWithFallback.ts
+++ b/frontend/src/hooks/useChordSheetWithFallback.ts
@@ -96,7 +96,7 @@ export function useChordSheetWithFallback(path: string): ChordSheetWithFallbackS
   // full arrangement is stored yet. This covers both the fresh-scrape case
   // (variant === 'simplified') and re-opening a cached song.
   const primarySongChords = localContent?.songChords ?? apiData?.songChords ?? null;
-  const primaryHasTabs = !!primarySongChords && (primarySongChords.includes('[TAB]') || (localContent?.rawHtml?.includes('tablatura') ?? false));
+  const primaryHasTabs = !!primarySongChords && (/^[EBGDAe]\|[-\d]/m.test(primarySongChords) || (localContent?.rawHtml?.includes('tablatura') ?? false));
   useEffect(() => {
     if (!path) return;
     if (fullContent) return;              // already have it

--- a/frontend/src/pages/chord-viewer/index.tsx
+++ b/frontend/src/pages/chord-viewer/index.tsx
@@ -3,6 +3,7 @@ import { useParams, useLocation, useSearchParams } from 'react-router-dom';
 import SongViewer, { type UpdatedSongData } from '@/components/SongViewer';
 import { useChordSheetWithFallback } from '@/hooks/useChordSheetWithFallback';
 import type { RouteParams } from './chord-viewer.types';
+import type { ChordSheet } from '@chordium/types';
 
 import { resolveChordSheetPath } from './utils/path-resolver';
 import { type JamPayload, decodeChordSheet, JAM_QR_PREFIX } from '@/utils/chordSheetQR';
@@ -162,20 +163,27 @@ const ChordViewer = () => {
       // way displayContent does below - editedData first - since
       // chordSheetResult.content is only populated once on mount and would
       // otherwise clobber a simplified edit just saved earlier this session.
-      await storeFullChordSheet({ songChords: data.songChords }, path);
-      await storeChordSheet(
-        metadata,
-        { songChords: resolveSimplifiedContentForFullEdit(editedData?.songChords, chordSheetResult.content?.songChords) },
-        isSaved,
-        path
-      );
+      const fullContent: ChordSheet = { songChords: data.songChords };
+      if (chordSheetResult.fullContent?.rawHtml) {
+        fullContent.rawHtml = chordSheetResult.fullContent.rawHtml;
+      }
+      await storeFullChordSheet(fullContent, path);
+      const simplifiedContent: ChordSheet = { songChords: resolveSimplifiedContentForFullEdit(editedData?.songChords, chordSheetResult.content?.songChords) };
+      if (chordSheetResult.content?.rawHtml) {
+        simplifiedContent.rawHtml = chordSheetResult.content.rawHtml;
+      }
+      await storeChordSheet(metadata, simplifiedContent, isSaved, path);
       setFullEdited(data.songChords);
     } else {
       // Editing the simplified (default) arrangement.
-      await storeChordSheet(metadata, { songChords: data.songChords }, isSaved, path);
+      const content: ChordSheet = { songChords: data.songChords };
+      if (chordSheetResult.content?.rawHtml) {
+        content.rawHtml = chordSheetResult.content.rawHtml;
+      }
+      await storeChordSheet(metadata, content, isSaved, path);
       setEditedData(data);
     }
-  }, [isSaved, path, showFull, editedData, chordSheetResult.content]);
+  }, [isSaved, path, showFull, editedData, chordSheetResult.content, chordSheetResult.fullContent]);
 
   if (jamPayload && !chordSheetResult.metadata) {
     const jamChordSheet = {

--- a/frontend/src/storage/hooks/use-chord-sheet-save.ts
+++ b/frontend/src/storage/hooks/use-chord-sheet-save.ts
@@ -1,3 +1,4 @@
+import type { ChordSheet } from "@chordium/types";
 import type { ChordSheetData } from "@/pages/chord-viewer/chord-viewer.types";
 import storeChordSheet from "@/storage/stores/chord-sheets/operations/store-chord-sheet";
 import { showSaveSuccessNotification, showSaveErrorNotification } from "@/pages/chord-viewer/utils/notifications";
@@ -23,10 +24,14 @@ export function useChordSheetSave(
     
     try {
       // Store chord sheet with saved: true (creates new or updates existing to saved: true)
-      const { title, artist, songKey, guitarTuning, guitarCapo, songChords } = chordSheetData.chordSheet;
+      const { title, artist, songKey, guitarTuning, guitarCapo, songChords, rawHtml } = chordSheetData.chordSheet;
+      const content: ChordSheet = { songChords };
+      if (rawHtml) {
+        content.rawHtml = rawHtml;
+      }
       await storeChordSheet(
         { title, artist, songKey, guitarTuning, guitarCapo },
-        { songChords },
+        content,
         true,
         chordSheetData.path
       );

--- a/frontend/src/utils/chord-html/remove-tabs-from-html.ts
+++ b/frontend/src/utils/chord-html/remove-tabs-from-html.ts
@@ -1,9 +1,16 @@
 export function removeTabsFromHtml(html: string): string {
-  let result = html.replace(/<span class="tablatura"[^>]*>[\s\S]*?<\/span>\s*<\/span>/g, '');
-  result = result.replace(/(​|&ZeroWidthSpace;)/g, '');
+  // Remove each "Tab - <title>" section wholesale: header, chord annotations,
+  // "Parte N de M" labels, dash lines, fret-hand arrows — everything up to
+  // the next header or the end of the content. Stripping only the specific
+  // tab artifacts (below) left chord-annotation lines behind with no header,
+  // which reads as broken content rather than a hidden section.
+  let result = html.replace(/<span class="section-title">\s*[Tt]ab\b[^<]*<\/span>[\s\S]*?(?=<span class="section-title">|$)/g, '');
 
-  // Remove tab-only section titles (e.g. "Tab - Solo Final") — they only label
-  // a tab block, which is now gone.
+  // Fallback for content scraped before every tab run was guaranteed a
+  // "Tab -" header: strip the tab artifacts piecemeal wherever they still
+  // appear outside of one.
+  result = result.replace(/<span class="tablatura"[^>]*>[\s\S]*?<\/span>\s*<\/span>/g, '');
+  result = result.replace(/(​|&ZeroWidthSpace;)/g, '');
   result = result.replace(/<span class="section-title">\s*[Tt]ab\b[^<]*<\/span>\n*/g, '');
 
   // Remove standalone tab-part labels ("Parte 1 de 3") left over from tab blocks.

--- a/frontend/src/utils/chord-html/remove-tabs-from-html.ts
+++ b/frontend/src/utils/chord-html/remove-tabs-from-html.ts
@@ -7,11 +7,16 @@ export function removeTabsFromHtml(html: string): string {
   result = result.replace(/<span class="section-title">\s*[Tt]ab\b[^<]*<\/span>\n*/g, '');
 
   // Remove standalone tab-part labels ("Parte 1 de 3") left over from tab blocks.
-  result = result.replace(/^[ \t]*Parte \d+ de \d+[ \t]*$\n?/gm, '');
+  // The source capitalizes "de" inconsistently ("Parte 01 De 04" vs "Parte 02 de 04").
+  result = result.replace(/^[ \t]*Parte \d+ [Dd]e \d+[ \t]*$\n?/gm, '');
 
   // Remove orphaned tab-string lines (e.g. "E|-----|") that sit outside a
   // tablatura span, optionally wrapped in a tab-info span.
   result = result.replace(/^(?:<span class="tab-info">)?[ \t]*[EADGBe]\|[-\d][^\n]*$\n?/gm, '');
+
+  // Remove orphaned fret-hand direction indicator rows (e.g. "↓  ↑ ↓") that
+  // sit outside a tablatura span, right below the tab lines they annotate.
+  result = result.replace(/^[ \t]*[↓↑][ \t↓↑]*$\n?/gm, '');
 
   result = result.replace(/<span class="section-title">[^<]*<\/span>\n+(?=\s*(?:<span class="section-title">|$))/g, '');
   result = result.replace(/\n{3,}/g, '\n\n');

--- a/frontend/src/utils/chord-html/remove-tabs-from-html.ts
+++ b/frontend/src/utils/chord-html/remove-tabs-from-html.ts
@@ -1,30 +1,78 @@
-export function removeTabsFromHtml(html: string): string {
-  // Remove each "Tab - <title>" section wholesale: header, chord annotations,
-  // "Parte N de M" labels, dash lines, fret-hand arrows — everything up to
-  // the next header or the end of the content. Stripping only the specific
-  // tab artifacts (below) left chord-annotation lines behind with no header,
-  // which reads as broken content rather than a hidden section.
-  let result = html.replace(/<span class="section-title">\s*[Tt]ab\b[^<]*<\/span>[\s\S]*?(?=<span class="section-title">|$)/g, '');
+const TAB_TITLE_REGEX = /^(?:tab|dedilhado)\b/i;
 
-  // Fallback for content scraped before every tab run was guaranteed a
-  // "Tab -" header: strip the tab artifacts piecemeal wherever they still
-  // appear outside of one.
+function isTabHeaderLine(line: string): boolean {
+  const match = line.match(/<span class="section-title">\s*([^<]*)<\/span>/);
+  return !!match && TAB_TITLE_REGEX.test(match[1].trim());
+}
+
+/**
+ * Whether a line still belongs to a tab run in progress: dash-drawn tab
+ * lines, "Parte N de M" labels, fret-hand direction rows, blank lines, or a
+ * chord-only annotation line that itself precedes more tab content (as
+ * opposed to one that precedes the section's real lyrics, which should stay).
+ */
+function isTabRunContinuation(lines: string[], i: number): boolean {
+  const line = lines[i];
+  const trimmed = line.trim();
+  if (trimmed === '') return true;
+  if (line.includes('<span class="tablatura">') || line.includes('<span class="cnt">') || line.includes('</span></span>')) {
+    return true;
+  }
+  if (/Parte \d+ [Dd]e \d+/.test(line)) return true;
+  if (/^[EBGDAe]\|[-\d]/.test(trimmed)) return true;
+  if (/^[ \t]*[↓↑][ \t↓↑]*$/.test(line)) return true;
+  if (/^(?:<b>[^<]*<\/b>\s*)+$/.test(trimmed)) {
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === '') j++;
+    if (j >= lines.length) return false;
+    const next = lines[j];
+    return (
+      next.includes('<span class="tablatura">') ||
+      next.includes('<span class="cnt">') ||
+      /Parte \d+ [Dd]e \d+/.test(next) ||
+      /^[EBGDAe]\|[-\d]/.test(next.trim())
+    );
+  }
+  return false;
+}
+
+export function removeTabsFromHtml(html: string): string {
+  // Remove each "Tab -"/"Dedilhado -" section's tab run wholesale: the
+  // header plus every line that's part of the tab run itself. Stops as soon
+  // as it reaches genuine lyric/chord content instead of jumping to the next
+  // header, since a section's real lyrics sometimes resume right after its
+  // tab block with no header of their own separating the two (the source
+  // shares one header, e.g. "[Primeira Parte]", between a leading tab block
+  // and the lyrics that follow it) — removing "to the next header" would
+  // have deleted those lyrics along with the tab.
+  const lines = html.split('\n');
+  const kept: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (isTabHeaderLine(lines[i])) {
+      i++;
+      while (i < lines.length && isTabRunContinuation(lines, i)) i++;
+      continue;
+    }
+    kept.push(lines[i]);
+    i++;
+  }
+  let result = kept.join('\n');
+
+  // Fallback for a tablatura span with no governing "Tab -"/"Dedilhado -"
+  // header at all (e.g. content scraped before every tab run was guaranteed
+  // one) — strip the tab artifacts piecemeal wherever they still appear.
   result = result.replace(/<span class="tablatura"[^>]*>[\s\S]*?<\/span>\s*<\/span>/g, '');
   result = result.replace(/(​|&ZeroWidthSpace;)/g, '');
-  result = result.replace(/<span class="section-title">\s*[Tt]ab\b[^<]*<\/span>\n*/g, '');
-
-  // Remove standalone tab-part labels ("Parte 1 de 3") left over from tab blocks.
-  // The source capitalizes "de" inconsistently ("Parte 01 De 04" vs "Parte 02 de 04").
+  result = result.replace(/<span class="section-title">\s*(?:[Tt]ab|[Dd]edilhado)\b[^<]*<\/span>\n*/g, '');
   result = result.replace(/^[ \t]*Parte \d+ [Dd]e \d+[ \t]*$\n?/gm, '');
-
-  // Remove orphaned tab-string lines (e.g. "E|-----|") that sit outside a
-  // tablatura span, optionally wrapped in a tab-info span.
   result = result.replace(/^(?:<span class="tab-info">)?[ \t]*[EADGBe]\|[-\d][^\n]*$\n?/gm, '');
-
-  // Remove orphaned fret-hand direction indicator rows (e.g. "↓  ↑ ↓") that
-  // sit outside a tablatura span, right below the tab lines they annotate.
   result = result.replace(/^[ \t]*[↓↑][ \t↓↑]*$\n?/gm, '');
 
+  // A header now immediately followed by another header (or the end) is an
+  // orphan left bare by the removal above — e.g. a section that was 100%
+  // tab content has nothing left under its own header once the tab run is
+  // gone, so drop it too.
   result = result.replace(/<span class="section-title">[^<]*<\/span>\n+(?=\s*(?:<span class="section-title">|$))/g, '');
   result = result.replace(/\n{3,}/g, '\n\n');
   result = result.replace(/\n+(<span class="section-title">[^<]*<\/span>)\n+/g, '\n\n$1\n');

--- a/frontend/src/utils/chord-sheet-utils.ts
+++ b/frontend/src/utils/chord-sheet-utils.ts
@@ -17,7 +17,7 @@ export interface ChordSection {
 // Trailing (?![A-Za-z0-9#]) instead of \b so sharp chords ending in '#'
 // (e.g. F#, C#, D/F#) are fully matched — a \b after '#' fails before a space,
 // which previously dropped the '#' and broke chord-line detection.
-export const CHORD_REGEX = /\b([A-G][#b]?(?:m|maj|min|aug|dim|sus|add|maj7|m7|7|9|11|13|6|m6|m9|m11|m13|7sus4|7sus2|7b5|7b9|7#9|7#11|7#5|aug7|dim7|4|2)?(?:\/[A-G][#b]?)?)(?![A-Za-z0-9#])/g;
+export const CHORD_REGEX = /\b([A-G][#b]?(?:m|maj|min|aug|dim|sus|add|maj7|m7|7M|9M|11M|13M|7|9|11|13|6|m6|m9|m11|m13|7sus4|7sus2|7b5|7b9|7#9|7#11|7#5|aug7|dim7|4|2)?(?:\/[A-G][#b]?)?)(?![A-Za-z0-9#])/g;
 
 function isChordLine(line: string): boolean {
   CHORD_REGEX.lastIndex = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chordium-monorepo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chordium-monorepo",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "workspaces": [
         "frontend",
         "backend",
@@ -27,7 +27,7 @@
     },
     "backend": {
       "name": "chordium-backend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@chordium/scraping": "*",
@@ -68,7 +68,7 @@
     },
     "frontend": {
       "name": "chordium-frontend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@chordium/scraping": "*",
         "@chordium/types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chordium-monorepo",
   "description": "A modern, minimalist chord viewer for beginner guitarists and hobbyists. View guitar chords without visual distractions.",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [

--- a/packages/scraping/src/cascade.ts
+++ b/packages/scraping/src/cascade.ts
@@ -100,7 +100,7 @@ async function runCascade(
     logger?.(`cascade: trying ${route.variant} → ${route.url}`);
     const data = await tryLoadVariant(page, route.url, route.timeout, logger);
     if (data) {
-      const hasTabs = data.songChords.includes("[TAB]");
+      const hasTabs = /^[EBGDAe]\|[-\d]/m.test(data.songChords);
       logger?.(`cascade hit: ${route.variant} (hasTabs=${hasTabs})`);
       return { data, variant: route.variant, hasTabs };
     }

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -14,9 +14,12 @@ import type { ChordSheet, SongMetadata, GuitarTuning } from "@chordium/types";
  *
  * Works on both regular song pages and print pages (`imprimir.html`), which
  * render some metadata differently (bare text / bare h2 instead of anchors).
+ * Print pages also paginate long songs across multiple `<pre>` elements (one
+ * per printed page) — every `<pre>` on the page is read and concatenated, since
+ * reading only the first silently drops the rest of the song.
  */
 export function extractFullChordSheet(): ChordSheet & SongMetadata {
-  const preElement = document.querySelector("pre");
+  const preElements = Array.from(document.querySelectorAll("pre"));
   let songChords = "";
   let rawHtml: string | undefined;
   // Non-standard tunings are usually a `span#cifra_afi a` anchor, but some
@@ -26,25 +29,49 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
   const leadingTuningLineRegex = /^Afinação:\s*([A-G][#b]?(?:\s+[A-G][#b]?){5})\s*\n+/i;
   let leadingTuningMatch: RegExpMatchArray | null = null;
 
-  if (preElement) {
-    // Plain-text content (tab blocks wrapped in [TAB] markers).
-    preElement.childNodes.forEach(function (node) {
-      if (node.nodeType === Node.TEXT_NODE) {
-        songChords += node.textContent || "";
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const el = node as Element;
-        if (el.classList.contains("tablatura")) {
-          songChords += "[TAB]\n" + (el.textContent || "") + "\n[/TAB]\n";
-        } else {
-          songChords += el.textContent || "";
+  // Drops a bare section-title line when it's immediately followed (skipping
+  // blank lines) by another one — the source sometimes repeats a section's
+  // title right before its "Tab - <title>" counterpart with nothing of
+  // substance in between, which reads as a useless duplicate header.
+  function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    for (const line of lines) {
+      if (isHeaderLine(line.trim())) {
+        while (result.length > 0 && result[result.length - 1].trim() === "") {
+          result.pop();
+        }
+        if (result.length > 0 && isHeaderLine(result[result.length - 1].trim())) {
+          result.pop();
         }
       }
+      result.push(line);
+    }
+    return result.join("\n");
+  }
+
+  if (preElements.length > 0) {
+    // Plain-text content. Tab blocks are plain text too (their dash-drawn
+    // strings, e.g. "E|----7-10-...|", are already self-identifying), so no
+    // wrapper markers are needed — and none are added, since bracket-style
+    // markers would collide with the "[Section]" convention used elsewhere
+    // and render as bogus section headers when rawHtml is unavailable.
+    preElements.forEach((preElement) => {
+      preElement.childNodes.forEach(function (node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          songChords += node.textContent || "";
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          songChords += (node as Element).textContent || "";
+        }
+      });
+      songChords += "\n";
     });
 
     leadingTuningMatch = songChords.match(leadingTuningLineRegex);
     if (leadingTuningMatch) {
       songChords = songChords.slice(leadingTuningMatch[0].length);
     }
+    songChords = dedupeAdjacentHeaders(songChords, (line) => /^\[[^\]]+\]$/.test(line));
 
     // rawHtml: keep only text, <b> (chords) and <span> (styling), stripping all
     // attributes except class on span. Preserves the source's chord markup.
@@ -64,7 +91,9 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       return `${openTag}${inner}</${tag}>`;
     }
 
-    let rawHtmlRaw = Array.from(preElement.childNodes).map(sanitizeNode).join("");
+    let rawHtmlRaw = preElements
+      .map((preElement) => Array.from(preElement.childNodes).map(sanitizeNode).join("") + "\n")
+      .join("");
     // Same leading line as above, verbatim (it's a plain text node, not
     // wrapped in <b>/<span>, so it appears unchanged in the sanitized HTML).
     rawHtmlRaw = rawHtmlRaw.replace(leadingTuningLineRegex, "");
@@ -93,29 +122,32 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         result.push(lines[i]);
       }
     }
-    rawHtml = result
-      .join("\n")
-      .replace(/\n{2,}(<span class="section-title">)/g, "\n\n$1")
-      .replace(/(<\/span>)\n\n+/g, "$1\n")
-      .replace(
-        /(<span class="tablatura">)((?:(?!<span class="cnt">)[\s\S])*?)(<span class="cnt">)/g,
-        (_m: string, open: string, content: string, cnt: string) => {
-          const contentLines = content.split("\n");
-          const tabInfoLines: string[] = [];
-          const chordAnnotationLines: string[] = [];
-          for (const line of contentLines) {
-            if (line.includes("<b>") && !line.includes('<span class="section-title">')) {
-              chordAnnotationLines.push(line);
-            } else if (line.trim() && !line.includes('<span class="section-title">')) {
-              tabInfoLines.push('<span class="tab-info">' + line + "</span>");
-            } else {
-              tabInfoLines.push(line);
+    rawHtml = dedupeAdjacentHeaders(
+      result
+        .join("\n")
+        .replace(/\n{2,}(<span class="section-title">)/g, "\n\n$1")
+        .replace(/(<\/span>)\n\n+/g, "$1\n")
+        .replace(
+          /(<span class="tablatura">)((?:(?!<span class="cnt">)[\s\S])*?)(<span class="cnt">)/g,
+          (_m: string, open: string, content: string, cnt: string) => {
+            const contentLines = content.split("\n");
+            const tabInfoLines: string[] = [];
+            const chordAnnotationLines: string[] = [];
+            for (const line of contentLines) {
+              if (line.includes("<b>") && !line.includes('<span class="section-title">')) {
+                chordAnnotationLines.push(line);
+              } else if (line.trim() && !line.includes('<span class="section-title">')) {
+                tabInfoLines.push('<span class="tab-info">' + line + "</span>");
+              } else {
+                tabInfoLines.push(line);
+              }
             }
+            const prefix = chordAnnotationLines.length > 0 ? chordAnnotationLines.join("\n") + "\n" : "";
+            return open + tabInfoLines.join("\n") + cnt + prefix;
           }
-          const prefix = chordAnnotationLines.length > 0 ? chordAnnotationLines.join("\n") + "\n" : "";
-          return open + tabInfoLines.join("\n") + cnt + prefix;
-        }
-      );
+        ),
+      (line) => /^<span class="section-title">.*<\/span>$/.test(line)
+    );
   }
 
   let title = "";

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -19,6 +19,12 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
   const preElement = document.querySelector("pre");
   let songChords = "";
   let rawHtml: string | undefined;
+  // Non-standard tunings are usually a `span#cifra_afi a` anchor, but some
+  // pages instead render a plain "Afinação: <notes>" line as the very first
+  // line of the pre block, with no anchor at all. Detected below and used
+  // both to strip it from the extracted content and as a tuning fallback.
+  const leadingTuningLineRegex = /^Afinação:\s*([A-G][#b]?(?:\s+[A-G][#b]?){5})\s*\n+/i;
+  let leadingTuningMatch: RegExpMatchArray | null = null;
 
   if (preElement) {
     // Plain-text content (tab blocks wrapped in [TAB] markers).
@@ -34,6 +40,11 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         }
       }
     });
+
+    leadingTuningMatch = songChords.match(leadingTuningLineRegex);
+    if (leadingTuningMatch) {
+      songChords = songChords.slice(leadingTuningMatch[0].length);
+    }
 
     // rawHtml: keep only text, <b> (chords) and <span> (styling), stripping all
     // attributes except class on span. Preserves the source's chord markup.
@@ -54,6 +65,9 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     }
 
     let rawHtmlRaw = Array.from(preElement.childNodes).map(sanitizeNode).join("");
+    // Same leading line as above, verbatim (it's a plain text node, not
+    // wrapped in <b>/<span>, so it appears unchanged in the sanitized HTML).
+    rawHtmlRaw = rawHtmlRaw.replace(leadingTuningLineRegex, "");
     // Some tab blocks close the tablatura span before the last string, leaving
     // the 6th string (e.g. "E|----|") as a bare line after </span></span>.
     // Absorb those trailing tab-string lines back inside the cnt span so the
@@ -190,6 +204,11 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       .trim()
       .split(/\s+/)
       .filter(Boolean);
+    if (notes.length === 6) {
+      guitarTuning = notes as unknown as GuitarTuning;
+    }
+  } else if (leadingTuningMatch) {
+    const notes = leadingTuningMatch[1].trim().split(/\s+/).filter(Boolean);
     if (notes.length === 6) {
       guitarTuning = notes as unknown as GuitarTuning;
     }

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -32,20 +32,48 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
   // Drops a bare section-title line when it's immediately followed (skipping
   // blank lines) by another one — the source sometimes repeats a section's
   // title right before its "Tab - <title>" counterpart with nothing of
-  // substance in between, which reads as a useless duplicate header.
+  // substance in between, which reads as a useless duplicate header. Only
+  // touches lines when a genuine duplicate is found — otherwise every line,
+  // including any surrounding blank ones, is left exactly as it was.
   function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
     const lines = text.split("\n");
     const result: string[] = [];
     for (const line of lines) {
       if (isHeaderLine(line.trim())) {
-        while (result.length > 0 && result[result.length - 1].trim() === "") {
-          result.pop();
-        }
-        if (result.length > 0 && isHeaderLine(result[result.length - 1].trim())) {
-          result.pop();
+        let j = result.length - 1;
+        while (j >= 0 && result[j].trim() === "") j--;
+        if (j >= 0 && isHeaderLine(result[j].trim())) {
+          result.length = j;
         }
       }
       result.push(line);
+    }
+    return result.join("\n");
+  }
+
+  // Ensures exactly one blank line before and after every header line (never
+  // zero, never more), except at the very start/end of the content where
+  // there's nothing to separate it from.
+  function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (isHeaderLine(line.trim())) {
+        while (result.length > 0 && result[result.length - 1].trim() === "") {
+          result.pop();
+        }
+        if (result.length > 0) result.push("");
+        result.push(line);
+        let k = i + 1;
+        while (k < lines.length && lines[k].trim() === "") k++;
+        if (k < lines.length) result.push("");
+        i = k;
+        continue;
+      }
+      result.push(line);
+      i++;
     }
     return result.join("\n");
   }
@@ -71,7 +99,9 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     if (leadingTuningMatch) {
       songChords = songChords.slice(leadingTuningMatch[0].length);
     }
-    songChords = dedupeAdjacentHeaders(songChords, (line) => /^\[[^\]]+\]$/.test(line));
+    const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
+    songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
+    songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
     // rawHtml: keep only text, <b> (chords) and <span> (styling), stripping all
     // attributes except class on span. Preserves the source's chord markup.
@@ -97,6 +127,37 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     // Same leading line as above, verbatim (it's a plain text node, not
     // wrapped in <b>/<span>, so it appears unchanged in the sanitized HTML).
     rawHtmlRaw = rawHtmlRaw.replace(leadingTuningLineRegex, "");
+    // Print pages render tab blocks as bare text with no <span class="tablatura">
+    // wrapper at all (unlike regular pages, whose native markup is preserved
+    // above by sanitizeNode) — their dash-drawn strings (e.g. "E|----7-10-...|")
+    // then inherit whatever font the reader picked instead of staying
+    // monospace, breaking the ASCII alignment. Detect and wrap them the same
+    // way the source's own regular pages do, so the existing .tablatura/.cnt
+    // CSS can force the alignment. Skipped when tablatura markup is already
+    // present (the regular-page fallback route) to avoid double-wrapping.
+    if (!/<span class="tablatura">/.test(rawHtmlRaw)) {
+      const tabLineRegex = /^[EBGDAe]\|[-\d]/;
+      const rawLines = rawHtmlRaw.split("\n");
+      const wrapped: string[] = [];
+      let idx = 0;
+      while (idx < rawLines.length) {
+        if (tabLineRegex.test(rawLines[idx])) {
+          const block: string[] = [];
+          while (
+            idx < rawLines.length &&
+            (tabLineRegex.test(rawLines[idx]) || (block.length > 0 && rawLines[idx].trim() === ""))
+          ) {
+            if (tabLineRegex.test(rawLines[idx])) block.push(rawLines[idx]);
+            idx++;
+          }
+          wrapped.push('<span class="tablatura"><span class="cnt">' + block.join("\n") + "</span></span>");
+        } else {
+          wrapped.push(rawLines[idx]);
+          idx++;
+        }
+      }
+      rawHtmlRaw = wrapped.join("\n");
+    }
     // Some tab blocks close the tablatura span before the last string, leaving
     // the 6th string (e.g. "E|----|") as a bare line after </span></span>.
     // Absorb those trailing tab-string lines back inside the cnt span so the
@@ -122,32 +183,31 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         result.push(lines[i]);
       }
     }
-    rawHtml = dedupeAdjacentHeaders(
-      result
-        .join("\n")
-        .replace(/\n{2,}(<span class="section-title">)/g, "\n\n$1")
-        .replace(/(<\/span>)\n\n+/g, "$1\n")
-        .replace(
-          /(<span class="tablatura">)((?:(?!<span class="cnt">)[\s\S])*?)(<span class="cnt">)/g,
-          (_m: string, open: string, content: string, cnt: string) => {
-            const contentLines = content.split("\n");
-            const tabInfoLines: string[] = [];
-            const chordAnnotationLines: string[] = [];
-            for (const line of contentLines) {
-              if (line.includes("<b>") && !line.includes('<span class="section-title">')) {
-                chordAnnotationLines.push(line);
-              } else if (line.trim() && !line.includes('<span class="section-title">')) {
-                tabInfoLines.push('<span class="tab-info">' + line + "</span>");
-              } else {
-                tabInfoLines.push(line);
-              }
+    const isSectionTitleLine = (line: string) => /^<span class="section-title">.*<\/span>$/.test(line);
+    const rawHtmlBuilt = result
+      .join("\n")
+      .replace(/\n{2,}(<span class="section-title">)/g, "\n\n$1")
+      .replace(/(<\/span>)\n\n+/g, "$1\n")
+      .replace(
+        /(<span class="tablatura">)((?:(?!<span class="cnt">)[\s\S])*?)(<span class="cnt">)/g,
+        (_m: string, open: string, content: string, cnt: string) => {
+          const contentLines = content.split("\n");
+          const tabInfoLines: string[] = [];
+          const chordAnnotationLines: string[] = [];
+          for (const line of contentLines) {
+            if (line.includes("<b>") && !line.includes('<span class="section-title">')) {
+              chordAnnotationLines.push(line);
+            } else if (line.trim() && !line.includes('<span class="section-title">')) {
+              tabInfoLines.push('<span class="tab-info">' + line + "</span>");
+            } else {
+              tabInfoLines.push(line);
             }
-            const prefix = chordAnnotationLines.length > 0 ? chordAnnotationLines.join("\n") + "\n" : "";
-            return open + tabInfoLines.join("\n") + cnt + prefix;
           }
-        ),
-      (line) => /^<span class="section-title">.*<\/span>$/.test(line)
-    );
+          const prefix = chordAnnotationLines.length > 0 ? chordAnnotationLines.join("\n") + "\n" : "";
+          return open + tabInfoLines.join("\n") + cnt + prefix;
+        }
+      );
+    rawHtml = normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlBuilt, isSectionTitleLine), isSectionTitleLine);
   }
 
   let title = "";

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -30,23 +30,48 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
   let leadingTuningMatch: RegExpMatchArray | null = null;
 
   // Drops a bare section-title line when it's immediately followed (skipping
-  // blank lines) by another one — the source sometimes repeats a section's
-  // title right before its "Tab - <title>" counterpart with nothing of
-  // substance in between, which reads as a useless duplicate header. Only
-  // touches lines when a genuine duplicate is found — otherwise every line,
-  // including any surrounding blank ones, is left exactly as it was.
-  function dedupeAdjacentHeaders(text: string, isHeaderLine: (line: string) => boolean): string {
+  // blank lines) by another one, but ONLY when that's actually safe: if the
+  // second header is "Tab -"/"Dedilhado -" prefixed, its tab run is skipped
+  // ahead first, and the drop only happens if nothing but another header (or
+  // the end) follows. Some sections share one header for both a tab run and
+  // the real chords/lyrics that resume right after it (e.g. a bare "[X]"
+  // immediately followed by "[Tab - X]", with the section's actual lyrics
+  // appearing only after the tab content ends) — collapsing the pair there
+  // would leave that trailing content with no header of its own. Sections
+  // that really are just a duplicate ("[X]" then "[Tab - X]" with nothing
+  // else in the section) still collapse to the more specific one as before.
+  function dedupeAdjacentHeaders(
+    text: string,
+    isHeaderLine: (line: string) => boolean,
+    extractTitle: (line: string) => string | null,
+    isTabContinuation: (lines: string[], i: number) => boolean
+  ): string {
     const lines = text.split("\n");
     const result: string[] = [];
-    for (const line of lines) {
-      if (isHeaderLine(line.trim())) {
-        let j = result.length - 1;
-        while (j >= 0 && result[j].trim() === "") j--;
-        if (j >= 0 && isHeaderLine(result[j].trim())) {
-          result.length = j;
+    let i = 0;
+    while (i < lines.length) {
+      if (isHeaderLine(lines[i].trim())) {
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim() === "") j++;
+        if (j < lines.length && isHeaderLine(lines[j].trim())) {
+          const nextTitle = extractTitle(lines[j].trim());
+          const nextIsTabPrefixed = !!nextTitle && /^(tab|dedilhado)\b/i.test(nextTitle.trim());
+          if (nextIsTabPrefixed) {
+            let k = j + 1;
+            while (k < lines.length && isTabContinuation(lines, k)) k++;
+            const safeToCollapse = k >= lines.length || isHeaderLine(lines[k].trim());
+            if (safeToCollapse) {
+              i = j;
+              continue;
+            }
+          } else {
+            i = j;
+            continue;
+          }
         }
       }
-      result.push(line);
+      result.push(lines[i]);
+      i++;
     }
     return result.join("\n");
   }
@@ -103,7 +128,7 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         result.push(line);
         continue;
       }
-      if (!insertedForSection && currentTitle && !/^tab\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
+      if (!insertedForSection && currentTitle && !/^(tab|dedilhado)\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
         result.push(makeHeaderLine("Tab - " + currentTitle));
         insertedForSection = true;
       }
@@ -133,6 +158,33 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     if (leadingTuningMatch) {
       songChords = songChords.slice(leadingTuningMatch[0].length);
     }
+    // Recognizes a chord-only line (e.g. "   Am               C   ") the same
+    // way isChordLine elsewhere in the app does: strip every chord token and
+    // check that nothing but whitespace/decoration is left.
+    const CHORD_TOKEN_SOURCE =
+      "[A-G][#b]?(?:m|maj|min|aug|dim|sus|add|maj7|m7|7M|9M|11M|13M|7|9|11|13|6|m6|m9|m11|m13|7sus4|7sus2|7b5|7b9|7#9|7#11|7#5|aug7|dim7|4|2)?(?:\\/[A-G][#b]?)?";
+    function isPlainChordOnlyLine(line: string): boolean {
+      if (!/[A-G]/.test(line)) return false;
+      const stripped = line.replace(new RegExp(CHORD_TOKEN_SOURCE, "g"), "");
+      return /^[\s()[\]{}xX0-9.,:-]*$/.test(stripped);
+    }
+    function isPlainTabContinuation(lines: string[], i: number): boolean {
+      const line = lines[i];
+      const trimmed = line.trim();
+      if (trimmed === "") return true;
+      if (/^[EBGDAe]\|[-\d]/.test(trimmed)) return true;
+      if (/^\s*Parte \d+ [Dd]e \d+\s*$/.test(line)) return true;
+      if (/^[ \t]*[↓↑][ \t↓↑]*$/.test(line)) return true;
+      if (isPlainChordOnlyLine(trimmed)) {
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim() === "") j++;
+        if (j >= lines.length) return false;
+        const next = lines[j];
+        return /^[EBGDAe]\|[-\d]/.test(next.trim()) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(next);
+      }
+      return false;
+    }
+
     const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
     const isTabRunStartPlain = (line: string) => /^[EBGDAe]\|[-\d]/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
     songChords = insertMissingTabHeaders(
@@ -142,7 +194,12 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       (title) => "[" + title + "]",
       isTabRunStartPlain
     );
-    songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
+    songChords = dedupeAdjacentHeaders(
+      songChords,
+      isBareBracketHeader,
+      (line) => line.match(/^\[([^\]]+)\]/)?.[1] ?? null,
+      isPlainTabContinuation
+    );
     songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
     // rawHtml: keep only text, <b> (chords) and <span> (styling), stripping all
@@ -237,7 +294,41 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         result.push(lines[i]);
       }
     }
-    const isSectionTitleLine = (line: string) => /^<span class="section-title">.*<\/span>$/.test(line);
+    // Native regular-page markup wraps each tab sub-block in its own
+    // <span class="tablatura">, sometimes with a "[Section]" bracket right
+    // on the same line as its opening tag (e.g. simplified print pages'
+    // "<span class="tablatura">[Dedilhado - Intro]") — so a header line and
+    // a tab-continuation line can each start with that tag.
+    const isSectionTitleLine = (line: string) =>
+      /^(?:<span class="tablatura">)?<span class="section-title">.*<\/span>$/.test(line);
+    function isHtmlTabContinuation(lines: string[], i: number): boolean {
+      const line = lines[i];
+      const trimmed = line.trim();
+      if (trimmed === "") return true;
+      if (
+        line.includes('<span class="tablatura">') ||
+        line.includes('<span class="cnt">') ||
+        line.includes("</span></span>")
+      ) {
+        return true;
+      }
+      if (/Parte \d+ [Dd]e \d+/.test(line)) return true;
+      if (/^[EBGDAe]\|[-\d]/.test(trimmed)) return true;
+      if (/^[ \t]*[↓↑][ \t↓↑]*$/.test(line)) return true;
+      if (/^(?:<b>[^<]*<\/b>\s*)+$/.test(trimmed)) {
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim() === "") j++;
+        if (j >= lines.length) return false;
+        const next = lines[j];
+        return (
+          next.includes('<span class="tablatura">') ||
+          next.includes('<span class="cnt">') ||
+          /Parte \d+ [Dd]e \d+/.test(next) ||
+          /^[EBGDAe]\|[-\d]/.test(next.trim())
+        );
+      }
+      return false;
+    }
     const rawHtmlBuilt = result
       .join("\n")
       .replace(/\n{2,}(<span class="section-title">)/g, "\n\n$1")
@@ -262,14 +353,19 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         }
       );
     const isTabRunStartHtml = (line: string) => /^<span class="tablatura">/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+    const extractTitleHtml = (line: string) =>
+      line.match(/^(?:<span class="tablatura">)?<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null;
     const rawHtmlWithTabHeaders = insertMissingTabHeaders(
       rawHtmlBuilt,
-      (line) => /^<span class="section-title">/.test(line),
-      (line) => line.match(/^<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null,
+      (line) => /^(?:<span class="tablatura">)?<span class="section-title">/.test(line),
+      extractTitleHtml,
       (title) => '<span class="section-title">' + title + "</span>",
       isTabRunStartHtml
     );
-    rawHtml = normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine), isSectionTitleLine);
+    rawHtml = normalizeHeaderBlankLines(
+      dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine, extractTitleHtml, isHtmlTabContinuation),
+      isSectionTitleLine
+    );
   }
 
   let title = "";

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -78,6 +78,40 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     return result.join("\n");
   }
 
+  // Some sections mix chord-only content and a tab block under a single
+  // header with no separate "Tab - <title>" counterpart (the source doesn't
+  // always split them the way it does for e.g. "[Intro]" + "[Tab - Intro]").
+  // Without that second header, the "hide tabs" toggle has nothing tab-named
+  // to strip and leaves the tab block's "Parte N de M" labels and dash lines
+  // behind. Detect where a tab run starts inside a section whose header
+  // isn't already "Tab"-prefixed, and insert one right before it.
+  function insertMissingTabHeaders(
+    text: string,
+    isHeaderLine: (line: string) => boolean,
+    extractTitle: (line: string) => string | null,
+    makeHeaderLine: (title: string) => string,
+    isTabRunStart: (line: string) => boolean
+  ): string {
+    const lines = text.split("\n");
+    const result: string[] = [];
+    let currentTitle: string | null = null;
+    let insertedForSection = false;
+    for (const line of lines) {
+      if (isHeaderLine(line.trim())) {
+        currentTitle = extractTitle(line.trim());
+        insertedForSection = false;
+        result.push(line);
+        continue;
+      }
+      if (!insertedForSection && currentTitle && !/^tab\b/i.test(currentTitle.trim()) && isTabRunStart(line)) {
+        result.push(makeHeaderLine("Tab - " + currentTitle));
+        insertedForSection = true;
+      }
+      result.push(line);
+    }
+    return result.join("\n");
+  }
+
   if (preElements.length > 0) {
     // Plain-text content. Tab blocks are plain text too (their dash-drawn
     // strings, e.g. "E|----7-10-...|", are already self-identifying), so no
@@ -100,6 +134,14 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       songChords = songChords.slice(leadingTuningMatch[0].length);
     }
     const isBareBracketHeader = (line: string) => /^\[[^\]]+\]$/.test(line);
+    const isTabRunStartPlain = (line: string) => /^[EBGDAe]\|[-\d]/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+    songChords = insertMissingTabHeaders(
+      songChords,
+      (line) => /^\[[^\]]+\]/.test(line),
+      (line) => line.match(/^\[([^\]]+)\]/)?.[1] ?? null,
+      (title) => "[" + title + "]",
+      isTabRunStartPlain
+    );
     songChords = dedupeAdjacentHeaders(songChords, isBareBracketHeader);
     songChords = normalizeHeaderBlankLines(songChords, isBareBracketHeader);
 
@@ -170,11 +212,12 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       rawHtmlRaw = wrapped.join("\n");
     }
     // Some tab blocks close the tablatura span before the last string, leaving
-    // the 6th string (e.g. "E|----|") as a bare line after </span></span>.
-    // Absorb those trailing tab-string lines back inside the cnt span so the
-    // whole tab block renders together.
+    // the 6th string (e.g. "E|----|") as a bare line after </span></span> — or
+    // before a fret-hand direction row (e.g. "↓  ↑ ↓") that annotates the tab
+    // just above it. Absorb both back inside the cnt span so the whole tab
+    // block renders (and gets removed together when tabs are hidden) as one.
     rawHtmlRaw = rawHtmlRaw.replace(
-      /(<\/span>)(<\/span>)((?:\n[ \t]*[EADGBe]\|[-\d][^\n]*)+)/g,
+      /(<\/span>)(<\/span>)((?:\n(?:[ \t]*[EADGBe]\|[-\d][^\n]*|[ \t]*[↓↑][ \t↓↑]*))+)/g,
       (_m, closeCnt, closeTab, orphanLines) => orphanLines + closeCnt + closeTab
     );
     const lines = rawHtmlRaw.split("\n");
@@ -218,7 +261,15 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
           return open + tabInfoLines.join("\n") + cnt + prefix;
         }
       );
-    rawHtml = normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlBuilt, isSectionTitleLine), isSectionTitleLine);
+    const isTabRunStartHtml = (line: string) => /^<span class="tablatura">/.test(line) || /^\s*Parte \d+ [Dd]e \d+\s*$/.test(line);
+    const rawHtmlWithTabHeaders = insertMissingTabHeaders(
+      rawHtmlBuilt,
+      (line) => /^<span class="section-title">/.test(line),
+      (line) => line.match(/^<span class="section-title">([^<]*)<\/span>/)?.[1] ?? null,
+      (title) => '<span class="section-title">' + title + "</span>",
+      isTabRunStartHtml
+    );
+    rawHtml = normalizeHeaderBlankLines(dedupeAdjacentHeaders(rawHtmlWithTabHeaders, isSectionTitleLine), isSectionTitleLine);
   }
 
   let title = "";

--- a/packages/scraping/src/extractors.ts
+++ b/packages/scraping/src/extractors.ts
@@ -51,9 +51,10 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
     return result.join("\n");
   }
 
-  // Ensures exactly one blank line before and after every header line (never
-  // zero, never more), except at the very start/end of the content where
-  // there's nothing to separate it from.
+  // Ensures exactly one blank line before every header line (never zero,
+  // never more), except at the very start of the content where there's
+  // nothing to separate it from. No blank line is added after — the
+  // divider rendered under the header already provides that separation.
   function normalizeHeaderBlankLines(text: string, isHeaderLine: (line: string) => boolean): string {
     const lines = text.split("\n");
     const result: string[] = [];
@@ -68,7 +69,6 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
         result.push(line);
         let k = i + 1;
         while (k < lines.length && lines[k].trim() === "") k++;
-        if (k < lines.length) result.push("");
         i = k;
         continue;
       }
@@ -142,13 +142,24 @@ export function extractFullChordSheet(): ChordSheet & SongMetadata {
       let idx = 0;
       while (idx < rawLines.length) {
         if (tabLineRegex.test(rawLines[idx])) {
+          // A "Parte N de M" section can hold several dash-drawn string
+          // groups back to back, each meant to stay visually separated by
+          // exactly one blank line — collapse any run of several into one,
+          // but keep it (dropping it entirely is what merged them together).
           const block: string[] = [];
           while (
             idx < rawLines.length &&
             (tabLineRegex.test(rawLines[idx]) || (block.length > 0 && rawLines[idx].trim() === ""))
           ) {
-            if (tabLineRegex.test(rawLines[idx])) block.push(rawLines[idx]);
+            if (tabLineRegex.test(rawLines[idx])) {
+              block.push(rawLines[idx]);
+            } else if (block[block.length - 1]?.trim() !== "") {
+              block.push("");
+            }
             idx++;
+          }
+          while (block.length > 0 && block[block.length - 1].trim() === "") {
+            block.pop();
           }
           wrapped.push('<span class="tablatura"><span class="cnt">' + block.join("\n") + "</span></span>");
         } else {


### PR DESCRIPTION
## Summary
- The primary Save button (useChordSheetSave) dropped rawHtml unconditionally, so any freshly loaded song lost its scraped chord markup the moment it was saved
- On reload, the app regenerates HTML from plain-text songChords via a regex parser that did not recognize the Brazilian 7M/9M/11M/13M major-chord notation (e.g. C7M, G7M), so those chords rendered as plain lyrics
- Fixed both: preserve rawHtml on save (in the edit path and the primary save path), and extended the chord regex to recognize 7M/9M/11M/13M
- Some pages render non-standard tuning as a plain "Afinação: <notes>" line at the start of the chord sheet instead of the usual anchor element, so it leaked into the song content as a lyric line and the tuning fell back to standard E-A-D-G-B-E (e.g. mauro-henrique/em-teus-bracos, john-mayer/neon) — extractors now detect that line, use it as the tuning, and strip it from the content
- Tab-heavy songs were silently truncated: the source paginates long songs across multiple print-page `<pre>` elements, but the extractor only read the first one (e.g. john-mayer/neon lost everything past its third tab part) — now reads every `<pre>` on the page
- Removed the internal [TAB]/[/TAB] wrapper markers around tab blocks, since they collided with the "[Section]" bracket convention and rendered as bogus "TAB"/"/TAB" headers whenever the plain text had to be re-parsed; tab detection now checks for the tab notation itself instead
- Section headers show exactly one blank line before (never zero, never more) and none after — the divider line under the header already provides that separation
- Section headers now match the SearchResultsSection header style (font-semibold, tracking-tight, foreground color, gradient divider underneath) instead of the old purple-bordered accent
- Print-page tab blocks render as bare text with no monospace wrapper, breaking their ASCII alignment — they're now wrapped the same way the source's regular pages tag them, so the existing tablatura/cnt CSS applies, and multi-group tab blocks (e.g. "Parte 3 de 5") keep their internal blank-line spacing instead of getting merged into one unreadable block
- The "hide tabs" toggle left tab content behind in several cases: sections that share one header between a leading tab run and real chords/lyrics with no "Tab -" header of their own (john-mayer/slow-dancing-in-burning-room, john-mayer/gravity); tab sections labeled "Dedilhado -" (fingerpicking) instead of "Tab -" (jesse-aguiar/alivio); inconsistent "Parte N De 04" capitalization; and fret-hand direction rows (↓ ↑ ↓) left outside the tab block
- Hiding tabs now scans forward through a tab run's own content (dash lines, Parte labels, chord annotations, fret-hand arrows) and stops as soon as it reaches real lyrics, rather than assuming the next header marks the boundary — so a section's real lyrics that resume right after its tab block (no header of their own) are preserved instead of deleted along with the tab
- Bumped to 0.5.2 (bug fixes, no breaking changes)

## Test plan
- Open gabriel-guedes/em-teus-bracos in chordium, tap save, reload — chords like C7M, G7M, Em7, D7 still render as styled chords
- Open mauro-henrique/em-teus-bracos and john-mayer/neon — tuning shows correctly in the metadata panel and no "Afinação:" line appears in the song content
- Open john-mayer/neon — full song renders through its last tab section, tab blocks are monospace-aligned and readable, headers match the search results header style
- Open john-mayer/slow-dancing-in-burning-room, john-mayer/gravity, and jesse-aguiar/alivio, uncheck "Tabs" — tab content (Parte labels, dashes, arrows, Dedilhado-prefixed sections) is fully hidden, while real chords/lyrics that follow a tab run under the same header (e.g. alivio's "Primeira Parte") stay visible
