### PR TITLE
chore: add versioning and release documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ npm run clean        # Remove all node_modules and build artifacts
 - NEVER push directly to main/master — always use a feature branch and let the user merge via PR
 - No Co-Authored-By or Claude attribution in commits
 
+## Versioning & Tagging
+
+- **Semantic versioning:** PATCH for fixes, MINOR for features, MAJOR for breaking changes
+- **Version bump commits** must be in their own commit with message format `chore: bump to <version>` and touch all three `package.json` files
+- **After merging a version bump PR:** create a git tag `v<major>.<minor>.<patch>` pointing to that commit and push it to enable GitHub Releases
+  ```bash
+  git tag v0.5.0 <commit-hash>
+  git push origin v0.5.0
+  ```
+
+
 ## Local Development Notes
 
 - **Search requires both frontend and backend running.** The frontend alone is not enough — search, artist songs, and chord sheet fetching all proxy through the Express backend on port 3001. Always run `npm run dev` (or `npm run dev:fe` + `npm run dev:be` in separate terminals) when working on search-related features.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ npm run dev
 
 See [Getting Started](./docs/getting-started.md) for full setup and commands.
 
+## 🏷️ Versioning & Releases
+
+This project follows semantic versioning ([semver](https://semver.org/)):
+- **MAJOR** - Breaking changes
+- **MINOR** - New features (backwards compatible)
+- **PATCH** - Bug fixes (backwards compatible)
+
+Each version bump is tagged in git as `v<major>.<minor>.<patch>` (e.g., `v0.5.0`) and published as a GitHub Release. See [Releases](../../releases) for the full changelog.
+
+**For developers:** When you merge a version bump PR, create a corresponding git tag:
+```bash
+git tag v<major>.<minor>.<patch> <commit-hash>
+git push origin v<major>.<minor>.<patch>
+```
+
+Then add release notes on GitHub describing what changed in that version.
+
 ## 📝 License
 
 This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
- Document semantic versioning conventions and tagging workflow in `CLAUDE.md`
- Add Versioning & Releases section to README with developer instructions
- Push git tags for past version bumps (`v0.5.0`, `v0.5.1`, `v0.5.2`, `v0.6.0`) - not part of this diff since tags are independent refs, but done alongside this PR

Tags enable GitHub Releases and provide clear milestone markers for tracking app evolution.