### PR TITLE
chore: auto-tag version bumps on merge to main

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,33 @@
+#!/bin/sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Auto-tags a version bump that just landed via merge/pull on main, so a
+# release never depends on remembering a manual `git tag` step. Compares
+# package.json's version before and after this merge; if it changed and
+# isn't already tagged, tags HEAD and pushes it.
+#
+# Only runs on main: merging main into a feature branch (to pick up latest)
+# would otherwise falsely tag that branch's own merge commit for a version
+# that hasn't actually landed on main yet.
+
+if [ "$(git branch --show-current)" != "main" ]; then
+  exit 0
+fi
+
+extract_version() {
+  grep -m1 '"version"' | sed -E 's/.*"version": *"([^"]+)".*/\1/'
+}
+
+OLD_VERSION=$(git show ORIG_HEAD:package.json 2>/dev/null | extract_version)
+NEW_VERSION=$(extract_version < package.json)
+
+if [ -n "$NEW_VERSION" ] && [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+  TAG="v$NEW_VERSION"
+  if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "post-merge: $TAG already exists, skipping"
+  else
+    echo "post-merge: version bumped to $NEW_VERSION — tagging $TAG"
+    git tag "$TAG" HEAD
+    git push origin "$TAG"
+  fi
+fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/e2e-tests"
   ],
   "scripts": {
+    "prepare": "husky",
     "use-workspace": "node scripts/toggle-workspace-deps.js",
     "use-npm": "USE_NPM=true node scripts/toggle-workspace-deps.js",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary
- Adds `.husky/post-merge`, which tags `v<version>` and pushes it automatically whenever a merge/pull on `main` changes `package.json`'s version — no more remembering a manual `git tag` step after merging a version-bump PR
- Skips anything not on `main` (so merging `main` into a feature branch never tags that branch's own commit) and skips if the tag already exists
- Adds `"prepare": "husky"` to root `package.json` — without it, `.husky/_` (where git actually looks for hook scripts) never gets generated on `npm install`, so hooks silently never fire in a fresh clone or worktree. This was already true for the existing `pre-commit` typecheck hook; this PR fixes it for both
